### PR TITLE
GSA Triangle Count

### DIFF
--- a/src/main/java/example/GSATriangleCount.java
+++ b/src/main/java/example/GSATriangleCount.java
@@ -1,0 +1,207 @@
+package example;
+
+import example.util.TriangleCountData;
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.gsa.ApplyFunction;
+import org.apache.flink.graph.gsa.GatherFunction;
+import org.apache.flink.graph.gsa.Neighbor;
+import org.apache.flink.graph.gsa.SumFunction;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+
+import java.util.HashSet;
+
+/**
+ * This is an implementation of Schank and Wagner's triangle count algorithm,
+ * using a gather-sum-apply iteration.
+ *
+ * @see <a href="http://reports-archive.adm.cs.cmu.edu/anon/ml2013/CMU-ML-13-104.pdf">page 101</a>
+ */
+public class GSATriangleCount implements ProgramDescription {
+
+	public static void main(String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<Integer, NullValue>> edges = getEdgesDataSet(env);
+
+		Graph<Integer, NullValue, NullValue> graph = Graph.fromDataSet(edges, env);
+
+		final Graph<Integer, NullValue, NullValue> undirectedGraph = graph.getUndirected();
+
+		// initialize the vertex values
+		Graph<Integer, HashSet<Integer>, NullValue> mappedGraph = undirectedGraph
+				.mapVertices(new MapFunction<Vertex<Integer, NullValue>, HashSet<Integer>>() {
+					@Override
+					public HashSet<Integer> map(Vertex<Integer, NullValue> vertex) throws Exception {
+						HashSet<Integer> neighbors = new HashSet<Integer>();
+						neighbors.add(vertex.getId());
+
+						return neighbors;
+					}
+				});
+
+		DataSet<Vertex<Integer, HashSet<Integer>>> verticesWithNeighbors = mappedGraph
+				.runGatherSumApplyIteration(new GatherNeighborIds(), new AddAllNeighbors(), new UpdateNeighbors(),
+						maxItertations).getVertices();
+
+		// scatter phase
+		DataSet<Tuple1<Integer>> trianglesCountedThreeTimes = verticesWithNeighbors.join(edges).where(0).equalTo(0)
+				.with(new FormTargetIdSrcValueTuple())
+				.join(verticesWithNeighbors).where(0).equalTo(0)
+				.with(new IntersectNeighbors());
+
+		// each triangle is counted three times
+		DataSet<Tuple1<Integer>> numberOfTriangles = trianglesCountedThreeTimes.sum(0)
+				.map(new MapFunction<Tuple1<Integer>, Tuple1<Integer>>() {
+					@Override
+					public Tuple1<Integer> map(Tuple1<Integer> tripledValue) throws Exception {
+						return new Tuple1<Integer>(tripledValue.f0/3);
+					}
+				});
+
+		//emit result
+		if(fileOutput) {
+			numberOfTriangles.writeAsCsv(outputPath, "\n", ",");
+		} else {
+			numberOfTriangles.print();
+		}
+
+		env.execute("Executing GSA Triangle Count Example");
+	}
+
+	private static final class FormTargetIdSrcValueTuple implements FlatJoinFunction<Vertex<Integer,HashSet<Integer>>,
+			Edge<Integer,NullValue>, Tuple2<Integer, HashSet<Integer>>> {
+
+		@Override
+		public void join(Vertex<Integer, HashSet<Integer>> vertex,
+						 Edge<Integer, NullValue> edge,
+						 Collector<Tuple2<Integer, HashSet<Integer>>> collector) throws Exception {
+
+			collector.collect(new Tuple2<Integer, HashSet<Integer>>(edge.getTarget(),
+					vertex.getValue()));
+		}
+	}
+
+	private static final class IntersectNeighbors implements FlatJoinFunction<Tuple2<Integer,HashSet<Integer>>,
+			Vertex<Integer,HashSet<Integer>>, Tuple1<Integer>> {
+
+		@Override
+		public void join(Tuple2<Integer, HashSet<Integer>> trgIdWithSrcValue,
+						 Vertex<Integer, HashSet<Integer>> vertex,
+						 Collector<Tuple1<Integer>> collector) throws Exception {
+
+			HashSet<Integer> srcHashSet = trgIdWithSrcValue.f1;
+			HashSet<Integer> neighborHashSet = vertex.getValue();
+
+			// get the intersection
+			int unionPlusIntersection = srcHashSet.size() + neighborHashSet.size();
+			HashSet<Integer> unionSet = new HashSet<>();
+			unionSet.addAll(srcHashSet);
+			unionSet.addAll(neighborHashSet);
+
+			int intersection = unionPlusIntersection - unionSet.size();
+
+			collector.collect(new Tuple1<Integer>(intersection));
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Triangle Count UDFs
+	// --------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("serial")
+	private static final class GatherNeighborIds extends GatherFunction<HashSet<Integer>, NullValue, HashSet<Integer>> {
+
+		@Override
+		public HashSet<Integer> gather(Neighbor<HashSet<Integer>, NullValue> neighbor) {
+			return neighbor.getNeighborValue();
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class AddAllNeighbors extends SumFunction<HashSet<Integer>, NullValue, HashSet<Integer>> {
+
+		@Override
+		public HashSet<Integer> sum(HashSet<Integer> newValue, HashSet<Integer> currentValue) {
+			currentValue.addAll(newValue);
+			return currentValue;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class UpdateNeighbors extends ApplyFunction<Integer, HashSet<Integer>, HashSet<Integer>> {
+
+		@Override
+		public void apply(HashSet<Integer> addedValue, HashSet<Integer> originalValue) {
+			setResult(addedValue);
+		}
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+	private static Integer maxItertations = TriangleCountData.MAX_ITERATIONS;
+
+	private static boolean parseParameters(String [] args) {
+		if(args.length > 0) {
+			if(args.length != 3) {
+				System.err.println("Usage GSATriangleCount <edge path> <output path> <num iterations>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+			maxItertations = Integer.parseInt(args[2]);
+
+		} else {
+			System.out.println("Executing GSATriangleCount example with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage GSATriangleCount <edge path> <output path> <num iterations>");
+		}
+
+		return true;
+	}
+
+	private static DataSet<Edge<Integer, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+		if(fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(Integer.class, Integer.class)
+					.map(new MapFunction<Tuple2<Integer, Integer>, Edge<Integer, NullValue>>() {
+
+						@Override
+						public Edge<Integer, NullValue> map(Tuple2<Integer, Integer> tuple2) throws Exception {
+							return new Edge<Integer, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return TriangleCountData.getDefaultEdgeDataSet(env);
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return "GSA Triangle Count";
+	}
+}

--- a/src/main/java/example/util/TriangleCountData.java
+++ b/src/main/java/example/util/TriangleCountData.java
@@ -1,0 +1,35 @@
+package example.util;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.types.NullValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TriangleCountData {
+
+	public static final Integer MAX_ITERATIONS = 1;
+
+	public static final String EDGES = "1	2\n"+"1	3\n"+"2	3\n"+"2	6\n"+"3	4\n"+"3	5\n"+"3	6\n"+"4	5\n"+"6	7\n";
+
+	public static DataSet<Edge<Integer, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
+		List<Edge<Integer, NullValue>> edges = new ArrayList<Edge<Integer, NullValue>>();
+		edges.add(new Edge<Integer, NullValue>(1,2,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(1,3,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(2,3,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(2,6,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(3,4,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(3,5,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(3,6,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(4,5,NullValue.getInstance()));
+		edges.add(new Edge<Integer, NullValue>(6,7,NullValue.getInstance()));
+
+		return env.fromCollection(edges);
+	}
+
+	public static final String RESULTED_NUMBER_OF_TRIANGLES = "3";
+
+	private TriangleCountData() {}
+}

--- a/src/test/java/example/GSATriangleCountITCase.java
+++ b/src/test/java/example/GSATriangleCountITCase.java
@@ -1,0 +1,51 @@
+package example;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import example.util.TriangleCountData;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+
+@RunWith(Parameterized.class)
+public class GSATriangleCountITCase extends MultipleProgramsTestBase {
+
+	private String edgesPath;
+
+	private String resultPath;
+
+	private String expected;
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	public GSATriangleCountITCase(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Before
+	public void before() throws Exception {
+		resultPath = tempFolder.newFile().toURI().toString();
+		File edgesFile = tempFolder.newFile();
+		Files.write(TriangleCountData.EDGES, edgesFile, Charsets.UTF_8);
+		edgesPath = edgesFile.toURI().toString();
+	}
+
+	@Test
+	public void testGSATriangleCount() throws Exception {
+		GSATriangleCount.main(new String[]{edgesPath, resultPath, TriangleCountData.MAX_ITERATIONS + ""});
+		expected = TriangleCountData.RESULTED_NUMBER_OF_TRIANGLES;
+	}
+
+	@After
+	public void after() throws Exception {
+		compareResultsByLinesInMemory(expected, resultPath);
+	}
+}


### PR DESCRIPTION
I could not write an equivalent of the BSP Triangle Count(the one with the three supersteps) because the gsa we have in Flink right now does not have a getSuperStepNumber() method. This can be fixed by merging the GSA Page Rank example or the GSA Iteration Configuration PR. 

But I came across this nice algorithm(page 101) and implemented it: 
http://reports-archive.adm.cs.cmu.edu/anon/ml2013/CMU-ML-13-104.pdf

Problem is that it only needs one superstep to compute the number of triangles. For what we are tying to prove, I believe we need an algorithm that runs in more supersteps. Some feedback would be welcome! No rush, though. 

@vasia, this makes me wonder, once again: why don't we have a scatter phase in GSA like PowerGraph does? It would be an improvement to writing these two joins by hand... 
