### PR TITLE
Vertex-Centric Jaccard with node splitting

### DIFF
--- a/src/main/java/example/JaccardSimilarityMeasure.java
+++ b/src/main/java/example/JaccardSimilarityMeasure.java
@@ -1,24 +1,19 @@
 package example;
 
+import library.Jaccard;
 import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
-import org.apache.flink.graph.EdgeDirection;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.NeighborsFunction;
-import org.apache.flink.graph.NeighborsFunctionWithVertexValue;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.NullValue;
-import org.apache.flink.util.Collector;
 import util.JaccardSimilarityMeasureData;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.TreeMap;
 
 public class JaccardSimilarityMeasure implements ProgramDescription {
 
@@ -30,23 +25,28 @@ public class JaccardSimilarityMeasure implements ProgramDescription {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		DataSet<Edge<Long, NullValue>> edges = getEdgesDataSet(env);
+		DataSet<Edge<String, NullValue>> edges = getEdgesDataSet(env);
 
-		Graph<Long, NullValue, NullValue> graph = Graph.fromDataSet(edges, env);
+		Graph<String, HashSet<String>, NullValue> graph = Graph.fromDataSet(edges, new MapFunction<String, HashSet<String>>() {
+			@Override
+			public HashSet<String> map(String s) throws Exception {
+				HashSet<String> neighborsHashSet = new HashSet<String>();
+				neighborsHashSet.add(s);
+
+				return neighborsHashSet;
+			}
+		}, env);
 
 		// the result is stored within the vertex value
-		DataSet<Vertex<Long, Tuple2<HashSet<Long>,HashMap<Long, Double>>>> verticesWithNeighbors =
-				graph.groupReduceOnNeighbors(new GatherNeighbors(), EdgeDirection.ALL);
+		DataSet<Vertex<String, HashSet<String>>> verticesWithNeighbors =
+				Jaccard.getVerticesWithNeighbors(graph);
 
-		Graph<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>, NullValue> graphWithVertexValues =
-				Graph.fromDataSet(verticesWithNeighbors, edges, env);
-
-		Graph<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>, NullValue> undirectedGraph =
-				graphWithVertexValues.getUndirected();
+		Graph<String, HashSet<String>, NullValue> undirectedGraphWithVertexValues =
+				Graph.fromDataSet(verticesWithNeighbors, edges, env).getUndirected();
 
 		// simulate a vertex centric iteration with groupReduceOnNeighbors
-		DataSet<Vertex<Long, HashMap<Long, Double>>> verticesWithJaccardValues =
-				undirectedGraph.groupReduceOnNeighbors(new ComputeJaccard(), EdgeDirection.IN);
+		DataSet<Vertex<String, TreeMap<String, Double>>> verticesWithJaccardValues =
+				Jaccard.getVerticesWithJaccardValues(undirectedGraphWithVertexValues);
 
 		// emit result
 		if (fileOutput) {
@@ -62,79 +62,6 @@ public class JaccardSimilarityMeasure implements ProgramDescription {
 	@Override
 	public String getDescription() {
 		return "Vertex Jaccard Similarity Measure";
-	}
-
-	/**
-	 * Each vertex will have a HashSet containing its neighbors as value.
-	 */
-	@SuppressWarnings("serial")
-	private static final class GatherNeighbors implements NeighborsFunction<Long, NullValue, NullValue,
-			Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>> {
-
-		@Override
-		public void iterateNeighbors(Iterable<Tuple3<Long, Edge<Long, NullValue>, Vertex<Long, NullValue>>> neighbors,
-									 Collector<Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>> collector) throws Exception {
-
-			HashSet<Long> neighborsHashSet = new HashSet<Long>();
-			Tuple3<Long, Edge<Long, NullValue>, Vertex<Long, NullValue>> next = null;
-			Iterator<Tuple3<Long, Edge<Long, NullValue>, Vertex<Long, NullValue>>> neighborsIterator =
-					neighbors.iterator();
-
-			while (neighborsIterator.hasNext()) {
-				next = neighborsIterator.next();
-				neighborsHashSet.add(next.f2.getId());
-			}
-
-			collector.collect(new Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>(next.f0,
-					new Tuple2<>(neighborsHashSet, new HashMap<Long, Double>())));
-		}
-	}
-
-	/**
-	 * Each vertex will have a HashMap containing the Jaccard coefficient for each of its values.
-	 *
-	 * Consider the edge x-y
-	 * We denote by sizeX and sizeY, the neighbors hash set size of x and y respectively.
-	 * sizeX+sizeY = union + intersection of neighborhoods
-	 * size(hashSetX.addAll(hashSetY)).distinct = union of neighborhoods
-	 * The intersection can then be deduced.
-	 *
-	 * Jaccard Similarity is then, the intersection/union.
-	 */
-	@SuppressWarnings("serial")
-	private static final class ComputeJaccard implements NeighborsFunctionWithVertexValue<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>, NullValue,
-				Vertex<Long, HashMap<Long, Double>>> {
-
-		@Override
-		public void iterateNeighbors(Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>> vertex,
-									 Iterable<Tuple2<Edge<Long, NullValue>, Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>>> neighbors,
-									 Collector<Vertex<Long, HashMap<Long, Double>>> collector) throws Exception {
-
-			HashMap<Long, Double> jaccard = new HashMap<>();
-			Tuple2<Edge<Long, NullValue>, Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>> next = null;
-			Iterator<Tuple2<Edge<Long, NullValue>, Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>>>> neighborsIterator =
-					neighbors.iterator();
-
-			while (neighborsIterator.hasNext()) {
-				next = neighborsIterator.next();
-				Vertex<Long, Tuple2<HashSet<Long>, HashMap<Long, Double>>> neighborVertex = next.f1;
-
-				Long y = neighborVertex.getId();
-				HashSet<Long> neighborSetY = neighborVertex.getValue().f0;
-
-				double unionPlusIntersection = vertex.getValue().f0.size() + neighborSetY.size();
-				// within a HashSet, all elements are distinct
-				HashSet<Long> unionSet = new HashSet<>();
-				unionSet.addAll(vertex.getValue().f0);
-				unionSet.addAll(neighborSetY);
-				double union = unionSet.size();
-				double intersection = unionPlusIntersection - union;
-
-				jaccard.put(y, intersection / union);
-			}
-
-			collector.collect(new Vertex<Long, HashMap<Long, Double>>(vertex.getId(), jaccard));
-		}
 	}
 
 	// *************************************************************************
@@ -165,18 +92,18 @@ public class JaccardSimilarityMeasure implements ProgramDescription {
 	}
 
 	@SuppressWarnings("serial")
-	private static DataSet<Edge<Long, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+	private static DataSet<Edge<String, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
 
 		if(fileOutput) {
 			return env.readCsvFile(edgeInputPath)
 					.ignoreComments("#")
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
-					.types(Long.class, Long.class)
-					.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
 						@Override
-						public Edge<Long, NullValue> map(Tuple2<Long, Long> tuple2) throws Exception {
-							return new Edge<Long, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						public Edge<String, NullValue> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
 						}
 					});
 		} else {

--- a/src/main/java/example/NodeSplittingJaccard.java
+++ b/src/main/java/example/NodeSplittingJaccard.java
@@ -1,0 +1,198 @@
+package example;
+
+import library.Jaccard;
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import splitUtils.SplitVertex;
+import util.JaccardSimilarityMeasureData;
+import util.NodeSplittingData;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.TreeMap;
+
+public class NodeSplittingJaccard implements ProgramDescription {
+
+	public static void main(String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<String, NullValue>> edges = getEdgesDataSet(env);
+
+		Graph<String, HashSet<String>, NullValue> initialGraph = Graph.fromDataSet(edges, new MapFunction<String, HashSet<String>>() {
+
+			@Override
+			public HashSet<String> map(String s) throws Exception {
+				HashSet<String> neighborsHashSet = new HashSet<String>();
+				neighborsHashSet.add(s);
+
+				return neighborsHashSet;
+			}
+		}, env);
+
+		DataSet<Tuple2<String, Long>> verticesWithDegrees = initialGraph.getDegrees();
+
+		final double xMin = SplitVertex.retrieveXMin(verticesWithDegrees);
+
+		DataSet<Vertex<String, NullValue>> skewedVertices = SplitVertex.determineSkewedVertices(xMin,
+				verticesWithDegrees);
+
+		Graph<String, Tuple2<String, HashSet<String>>, NullValue> graphWithSplitVertices = SplitVertex.treeDeAggregate(skewedVertices, initialGraph,
+				alpha, level, xMin);
+
+		// compute neighbors
+		// the result is stored within the vertex value
+		DataSet<Vertex<String, HashSet<String>>> verticesWithNeighbors =
+				Jaccard.getVerticesWithNeighborsForSplitVertices(graphWithSplitVertices);
+
+		DataSet<Vertex<String, HashSet<String>>> aggregatedVertices =
+				SplitVertex.treeAggregate(verticesWithNeighbors, level, new AggregateNeighborSets());
+
+		// propagate computed aggregated values to the split vertices
+		// avoid a second treeDeAggregate
+		DataSet<Vertex<String, Tuple2<String, HashSet<String>>>> updatedSplittedVertices =
+				SplitVertex.propagateValuesToSplitVertices(graphWithSplitVertices.getVertices(),
+						aggregatedVertices);
+
+		Graph<String, Tuple2<String, HashSet<String>>, NullValue> graphWithNeighborsSplitVertices =
+				Graph.fromDataSet(updatedSplittedVertices, graphWithSplitVertices.getEdges(), env);
+
+		DataSet<Vertex<String, TreeMap<String, Double>>> verticesWithJaccardValues = Jaccard
+				.getVerticesWithJaccardValuesForSplitNodes(graphWithNeighborsSplitVertices);
+
+		// introduce the custom "combiner" used for aggregation
+		DataSet<Vertex<String, TreeMap<String, Double>>> aggregatedVerticesWithJaccardValues =
+				SplitVertex.treeAggregate(verticesWithJaccardValues, level, new AggregateJaccardSets());
+
+		// emit result
+		if (fileOutput) {
+			aggregatedVerticesWithJaccardValues.writeAsCsv(outputPath, "\n", ",");
+		} else {
+			aggregatedVerticesWithJaccardValues.print();
+		}
+
+		env.execute("Node Splitting Jaccard Similarity Measure");
+	}
+
+	@Override
+	public String getDescription() {
+		return "Jaccard with Split Vertices";
+	}
+
+	/**
+	 * UDF that describes the combining strategy: the partial hash sets containing neighbor values will be reduced
+	 * to a single hash set per vertex.
+	 */
+	@SuppressWarnings("serial")
+	private static final class AggregateNeighborSets implements GroupReduceFunction<Vertex<String, HashSet<String>>, Vertex<String, HashSet<String>>> {
+
+		@Override
+		public void reduce(Iterable<Vertex<String, HashSet<String>>> vertex,
+						   Collector<Vertex<String, HashSet<String>>> collector) throws Exception {
+
+			Iterator<Vertex<String, HashSet<String>>> vertexIterator = vertex.iterator();
+			Vertex<String, HashSet<String>> next = null;
+			HashSet<String> neighborsPerVertex = new HashSet<>();
+			String id = null;
+
+			while (vertexIterator.hasNext()) {
+				next = vertexIterator.next();
+				id = next.getId();
+				neighborsPerVertex.addAll(next.getValue());
+			}
+			collector.collect(new Vertex<String, HashSet<String>>(id, neighborsPerVertex));
+		}
+	}
+
+	/**
+	 * UDF that describes the combining strategy: the partial tree maps with Jaccard values will be reduced to a single
+	 * tree map per vertex.
+	 */
+	@SuppressWarnings("serial")
+	private static final class AggregateJaccardSets implements GroupReduceFunction<Vertex<String, TreeMap<String, Double>>,
+			Vertex<String, TreeMap<String, Double>>> {
+
+		@Override
+		public void reduce(Iterable<Vertex<String, TreeMap<String, Double>>> vertex,
+						   Collector<Vertex<String, TreeMap<String, Double>>> collector) throws Exception {
+
+			Iterator<Vertex<String, TreeMap<String, Double>>> vertexIterator = vertex.iterator();
+			Vertex<String, TreeMap<String, Double>> next = null;
+			TreeMap<String, Double> result = new TreeMap<String, Double>();
+			String id = null;
+
+			while (vertexIterator.hasNext()) {
+				next = vertexIterator.next();
+				id = next.getId();
+				result.putAll(next.getValue());
+			}
+
+			collector.collect(new Vertex<String, TreeMap<String, Double>>(id, result));
+		}
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+
+	private static Integer alpha = NodeSplittingData.ALPHA;
+	private static Integer level = NodeSplittingData.LEVEL;
+
+	private static boolean parseParameters(String [] args) {
+		if(args.length > 0) {
+			if(args.length != 4) {
+				System.err.println("Usage NodeSplittingJaccard <edge path> <output path> <alpha> <level>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+			alpha = Integer.parseInt(args[2]);
+			level = Integer.parseInt(args[3]);
+		} else {
+			System.out.println("Executing NodeSplittingJaccard example with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage NodeSplittingJaccard <edge path> <output path> <alpha> <level>");
+		}
+
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<String, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+
+		if(fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
+						@Override
+						public Edge<String, NullValue> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return JaccardSimilarityMeasureData.getDefaultEdgeDataSet(env);
+		}
+	}
+}

--- a/src/main/java/library/Jaccard.java
+++ b/src/main/java/library/Jaccard.java
@@ -1,0 +1,175 @@
+package library;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.EdgeDirection;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.NeighborsFunction;
+import org.apache.flink.graph.NeighborsFunctionWithVertexValue;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.TreeMap;
+
+public class Jaccard {
+
+	public static DataSet<Vertex<String, HashSet<String>>> getVerticesWithNeighbors
+			(Graph<String, HashSet<String>, NullValue> graph) {
+
+		return graph.groupReduceOnNeighbors(new GatherNeighbors(), EdgeDirection.ALL);
+	}
+
+	public static DataSet<Vertex<String, HashSet<String>>> getVerticesWithNeighborsForSplitVertices
+			(Graph<String, Tuple2<String, HashSet<String>>, NullValue> graph) {
+
+		return graph.groupReduceOnNeighbors(new GatherNeighborsForSplitVertices(), EdgeDirection.ALL);
+	}
+
+	public static DataSet<Vertex<String, TreeMap<String, Double>>> getVerticesWithJaccardValues
+			(Graph<String, HashSet<String>, NullValue> undirectedGraphWithVertexValues) {
+
+		return undirectedGraphWithVertexValues.groupReduceOnNeighbors(new ComputeJaccard(), EdgeDirection.ALL);
+	}
+
+	public static DataSet<Vertex<String, TreeMap<String, Double>>> getVerticesWithJaccardValuesForSplitNodes
+			(Graph<String, Tuple2<String, HashSet<String>>, NullValue> undirectedGraphWithVertexValues) {
+
+		return undirectedGraphWithVertexValues.groupReduceOnNeighbors(new ComputeJaccardForSplitVertices(), EdgeDirection.ALL);
+	}
+
+	/**
+	 * Each vertex will have a HashSet containing its neighbors as value.
+	 */
+	@SuppressWarnings("serial")
+	private static final class GatherNeighbors implements NeighborsFunction<String, HashSet<String>, NullValue,
+			Vertex<String, HashSet<String>>> {
+
+		@Override
+		public void iterateNeighbors(Iterable<Tuple3<String, Edge<String, NullValue>, Vertex<String, HashSet<String>>>> neighbors,
+									 Collector<Vertex<String,HashSet<String>>> collector) throws Exception {
+
+			HashSet<String> neighborsHashSet = new HashSet<String>();
+			Tuple3<String, Edge<String, NullValue>, Vertex<String, HashSet<String>>> next = null;
+			Iterator<Tuple3<String, Edge<String, NullValue>, Vertex<String, HashSet<String>>>> neighborsIterator =
+					neighbors.iterator();
+
+			while (neighborsIterator.hasNext()) {
+				next = neighborsIterator.next();
+				neighborsHashSet.addAll(next.f2.getValue());
+			}
+
+			collector.collect(new Vertex<String, HashSet<String>>(next.f0,neighborsHashSet));
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class GatherNeighborsForSplitVertices implements NeighborsFunction<String, Tuple2<String, HashSet<String>>, NullValue,
+			Vertex<String,HashSet<String>>> {
+
+		@Override
+		public void iterateNeighbors(Iterable<Tuple3<String, Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>>> neighbors,
+										 Collector<Vertex<String, HashSet<String>>> collector) throws Exception {
+
+			HashSet<String> neighborsHashSet = new HashSet<String>();
+			Tuple3<String, Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>> next = null;
+			Iterator<Tuple3<String, Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>>> neighborsIterator =
+					neighbors.iterator();
+
+			while (neighborsIterator.hasNext()) {
+				next = neighborsIterator.next();
+				neighborsHashSet.addAll(next.f2.getValue().f1);
+			}
+
+			collector.collect(new Vertex<String, HashSet<String>>(next.f0,neighborsHashSet));
+		}
+	}
+
+	/**
+	 * Each vertex will have a HashMap containing the Jaccard coefficient for each of its values.
+	 *
+	 * Consider the edge x-y
+	 * We denote by sizeX and sizeY, the neighbors hash set size of x and y respectively.
+	 * sizeX+sizeY = union + intersection of neighborhoods
+	 * size(hashSetX.addAll(hashSetY)).distinct = union of neighborhoods
+	 * The intersection can then be deduced.
+	 *
+	 * Jaccard Similarity is then, the intersection/union.
+	 */
+	@SuppressWarnings("serial")
+	private static final class ComputeJaccard implements NeighborsFunctionWithVertexValue<String, HashSet<String>, NullValue,
+			Vertex<String, TreeMap<String, Double>>> {
+
+		@Override
+		public void iterateNeighbors(Vertex<String, HashSet<String>> vertex,
+									 Iterable<Tuple2<Edge<String, NullValue>, Vertex<String, HashSet<String>>>> neighbors,
+									 Collector<Vertex<String, TreeMap<String, Double>>> collector) throws Exception {
+
+			TreeMap<String, Double> jaccard = new TreeMap<>();
+			Tuple2<Edge<String, NullValue>, Vertex<String, HashSet<String>>> next = null;
+			Iterator<Tuple2<Edge<String, NullValue>, Vertex<String, HashSet<String>>>> neighborsIterator =
+					neighbors.iterator();
+
+			while (neighborsIterator.hasNext()) {
+				next = neighborsIterator.next();
+				Vertex<String, HashSet<String>> neighborVertex = next.f1;
+
+				String y = neighborVertex.getId();
+				HashSet<String> neighborSetY = neighborVertex.getValue();
+
+				double unionPlusIntersection = vertex.getValue().size() + neighborSetY.size();
+				// within a HashSet, all elements are distinct
+				HashSet<String> unionSet = new HashSet<>();
+				unionSet.addAll(vertex.getValue());
+				unionSet.addAll(neighborSetY);
+				double union = unionSet.size();
+				double intersection = unionPlusIntersection - union;
+
+				jaccard.put(y, intersection / union);
+			}
+
+			collector.collect(new Vertex<String, TreeMap<String, Double>>(vertex.getId(), jaccard));
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class ComputeJaccardForSplitVertices implements NeighborsFunctionWithVertexValue<String,
+			Tuple2<String,HashSet<String>>, NullValue,
+			Vertex<String, TreeMap<String, Double>>> {
+
+		@Override
+		public void iterateNeighbors(Vertex<String, Tuple2<String, HashSet<String>>> vertex,
+									 Iterable<Tuple2<Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>>> neighbors,
+									 Collector<Vertex<String, TreeMap<String, Double>>>  collector) throws Exception {
+
+			TreeMap<String, Double> jaccard = new TreeMap<>();
+			Tuple2<Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>> next = null;
+			Iterator<Tuple2<Edge<String, NullValue>, Vertex<String, Tuple2<String, HashSet<String>>>>> neighborsIterator =
+					neighbors.iterator();
+
+			while (neighborsIterator.hasNext()) {
+				next = neighborsIterator.next();
+				Vertex<String, Tuple2<String, HashSet<String>>> neighborVertex = next.f1;
+
+				String y = neighborVertex.getValue().f0;
+				HashSet<String> neighborSetY = neighborVertex.getValue().f1;
+
+				double unionPlusIntersection = vertex.getValue().f1.size() + neighborSetY.size();
+				// within a HashSet, all elements are distinct
+				HashSet<String> unionSet = new HashSet<>();
+				unionSet.addAll(vertex.getValue().f1);
+				unionSet.addAll(neighborSetY);
+				double union = unionSet.size();
+				double intersection = unionPlusIntersection - union;
+
+				jaccard.put(y, intersection / union);
+			}
+
+			collector.collect(new Vertex<String, TreeMap<String, Double>>(vertex.getId(), jaccard));
+		}
+	}
+}

--- a/src/main/java/splitUtils/SplitVertex.java
+++ b/src/main/java/splitUtils/SplitVertex.java
@@ -1,0 +1,413 @@
+package splitUtils;
+
+import nl.peterbloem.powerlaws.Continuous;
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.JoinFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import util.Sha;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Class containing methods that are generally applicable to a skewed node - splitting/aggregation methods.
+ */
+public class SplitVertex {
+
+	public static <K extends Comparable<K> & Serializable,
+			VV extends Serializable, EV extends Serializable> DataSet<Vertex<K, NullValue>> determineSkewedVertices(final double xMin,
+																													DataSet<Tuple2<K, Long>> verticesWithDegrees) throws Exception {
+		return verticesWithDegrees
+				.flatMap(new FlatMapFunction<Tuple2<K, Long>, Vertex<K, NullValue>>() {
+
+					@Override
+					public void flatMap(Tuple2<K, Long> vertexIdDegree,
+										Collector<Vertex<K, NullValue>> collector) throws Exception {
+						if(vertexIdDegree.f1 > xMin) {
+							collector.collect(new Vertex<K, NullValue>(vertexIdDegree.f0, NullValue.getInstance()));
+						}
+					}
+				});
+	}
+
+	public static <K extends Comparable<K> & Serializable> double retrieveXMin(DataSet<Tuple2<K, Long>> verticesWithDegrees) throws Exception {
+		// Data2Semantics takes an array of doubles representing the degrees, computes an
+		// xMin and everything above that threshold is skewed
+		DataSet<Double> degrees = verticesWithDegrees.map(new MapFunction<Tuple2<K, Long>, Double>() {
+
+			@Override
+			public Double map(Tuple2<K, Long> idDegreeTuple2) throws Exception {
+				return new Double(idDegreeTuple2.f1);
+			}
+		});
+
+		List<Double> arrayOfDegrees = degrees.collect();
+
+		Continuous distribution = Continuous.fit(arrayOfDegrees).fit();
+
+		return distribution.xMin();
+	}
+
+	/**
+	 * Method that takes the skewed vertices and splits them into alpha subvertices recursively,
+	 * forming a tree of `level` levels.
+	 *
+	 * The skewed vertex can be either the source or the destination of an edge. We hash its neighbor and add _ followed by
+	 * a unique identifier to the vertex ID.
+	 *
+	 * @param skewedVertices
+	 * @param graph - the initial graph
+	 * @param alpha - the number of subvertices in which a node should be split
+	 * @param level - the number of levels the tree will have
+	 * @param xMin - the threshold for determining skewed vertices
+	 *
+	 * @return a data set of edges formed from the skewed vertices and their subnodes
+	 */
+	public static <VV extends Serializable, EV extends Serializable> Graph<String, Tuple2<String, VV>, EV> treeDeAggregate(
+			DataSet<Vertex<String, NullValue>> skewedVertices,
+			Graph<String, VV, EV> graph,
+			final Integer alpha, Integer level,
+			final double xMin) {
+
+		DataSet<Edge<String, EV>> edgesWithSkewedVertices = graph.getEdges();
+		DataSet<Vertex<String, VV>> vertices = graph.getVertices();
+
+		for(int i=0; i<level; i++) {
+			edgesWithSkewedVertices = edgesWithSkewedVertices.coGroup(skewedVertices).where(0).equalTo(0)
+					.with(new SplitSourceCoGroup(i, alpha))
+					.coGroup(skewedVertices).where(1).equalTo(0)
+					.with(new SplitTargetCoGroup(i, alpha));
+
+			// update the data set of vertices so that the skewed, split vertices will also contain the original
+			// value of the vertex
+			vertices = vertices.coGroup(skewedVertices).where(0).equalTo(0)
+					.with(new SplitVerticesCoGroup<VV>(alpha));
+
+			// update the skewed vertices to also contain their subvertices
+			skewedVertices = skewedVertices.flatMap(new FlatMapFunction<Vertex<String, NullValue>, Vertex<String, NullValue>>() {
+				@Override
+				public void flatMap(Vertex<String, NullValue> vertex,
+									Collector<Vertex<String, NullValue>> collector) throws Exception {
+
+					for (int i = 0; i < alpha; i++) {
+						collector.collect(new Vertex<String, NullValue>(vertex.getId() + "_" + i, NullValue.getInstance()));
+					}
+				}
+			});
+
+			// see whether the subnodes are still skewed and then continue splitting until max level is reached
+			DataSet<Tuple2<String, Long>> skewedNodesWithDegrees = getDegreesSkewedNodes(edgesWithSkewedVertices,
+					skewedVertices);
+			skewedVertices = skewedNodesWithDegrees.flatMap(new FilterSkewedVertices(xMin));
+		}
+
+		DataSet<Vertex<String, Tuple2<String, VV>>> newVertices = vertices.map(new MapFunction<Vertex<String, VV>, Vertex<String, Tuple2<String, VV>>>() {
+			@Override
+			public Vertex<String, Tuple2<String, VV>> map(Vertex<String, VV> vertex) throws Exception {
+				if (vertex.getId().indexOf("_") <= -1) {
+					return new Vertex<String, Tuple2<String, VV>>(vertex.getId(), new Tuple2<String, VV>(vertex.getId(), vertex.getValue()));
+				} else {
+					int pos = vertex.getId().indexOf("_");
+
+					return new Vertex<String, Tuple2<String, VV>>(vertex.getId(), new Tuple2<String, VV>(
+							vertex.getId().substring(0, pos), vertex.getValue()));
+				}
+			}
+		});
+
+		return Graph.fromDataSet(newVertices, edgesWithSkewedVertices, graph.getContext());
+	}
+
+	private static class FilterSkewedVertices implements FlatMapFunction<Tuple2<String, Long>, Vertex<String, NullValue>> {
+
+		double xMin;
+
+		public FilterSkewedVertices(double xMin) {
+			this.xMin = xMin;
+		}
+
+		@Override
+		public void flatMap(Tuple2<String, Long> verticesWithDegrees,
+							Collector<Vertex<String, NullValue>> collector) throws Exception {
+			if(verticesWithDegrees.f1 > xMin) {
+				collector.collect(new Vertex<String, NullValue>(verticesWithDegrees.f0, NullValue.getInstance()));
+			}
+		}
+	}
+
+	private static <EV extends Serializable> DataSet<Tuple2<String, Long>> getDegreesSkewedNodes(
+			DataSet<Edge<String, EV>> edgesWithSkewedVertices,
+			DataSet<Vertex<String, NullValue>> skewedVertices) {
+
+		DataSet<Edge<String, EV>> edgesWithSplitSource = skewedVertices.join(edgesWithSkewedVertices).where(0).equalTo(0)
+				.with(new ProjectDuplicateEdge<EV>());
+		DataSet<Edge<String, EV>> edgeWithSplitTarget = skewedVertices.join(edgesWithSkewedVertices).where(0).equalTo(1)
+				.with(new ProjectDuplicateEdge<EV>());
+
+		DataSet<Edge<String, EV>> splitEdges = edgesWithSplitSource.union(edgeWithSplitTarget).distinct();
+
+		return splitEdges.groupBy(0).reduceGroup(new GroupReduceFunction<Edge<String, EV>, Tuple2<String, Long>>() {
+
+			@Override
+			public void reduce(Iterable<Edge<String, EV>> edges,
+							   Collector<Tuple2<String, Long>> collector) throws Exception {
+
+				Iterator<Edge<String, EV>> edgeIterator = edges.iterator();
+				Edge<String, EV> next = null;
+				long count = 0;
+				String id = null;
+
+				while (edgeIterator.hasNext()) {
+					next = edgeIterator.next();
+					id = next.getSource();
+					count ++;
+				}
+
+				collector.collect(new Tuple2<String, Long>(id, count));
+			}
+		});
+	}
+
+	private static class ProjectDuplicateEdge<EV> implements FlatJoinFunction<Vertex<String, NullValue>, Edge<String, EV>, Edge<String, EV>> {
+
+		@Override
+		public void join(Vertex<String, NullValue> vertex, Edge<String, EV> edge,
+						 Collector<Edge<String,EV>> collector) throws Exception {
+			collector.collect(edge);
+			collector.collect(new Edge<String, EV>(edge.getTarget(), edge.getSource(), edge.getValue()));
+		}
+	}
+
+	/**
+	 * Method that identifies the split vertices and adds up the partial results.
+	 *
+	 * @param resultedVertices the vertices resulted from the computation of the algorithm
+	 * @param level the number of levels in which a vertex is split
+	 * @param groupReduce the function on which to combine the values
+	 * @return
+	 */
+	public static <VV extends Serializable> DataSet<Vertex<String, VV>> treeAggregate(DataSet<Vertex<String, VV>> resultedVertices,
+																					   Integer level,
+																					   GroupReduceFunction<Vertex<String, VV>, Vertex<String, VV>> groupReduce) {
+
+		DataSet<Vertex<String, VV>> regularVertices = resultedVertices.filter(new FilterFunction<Vertex<String, VV>>() {
+
+			@Override
+			public boolean filter(Vertex<String, VV> vertex) throws Exception {
+
+				return (vertex.getId().indexOf("_") <= -1);
+			}
+		});
+
+		DataSet<Vertex<String, VV>> splitVertices = resultedVertices.filter(new FilterFunction<Vertex<String, VV>>() {
+
+			@Override
+			public boolean filter(Vertex<String, VV> vertex) throws Exception {
+
+				return (vertex.getId().indexOf("_") > -1);
+			}
+		});
+
+		// add up the partial values only for the split vertices
+		for(int i = 0; i < level; i++) {
+			splitVertices = splitVertices.flatMap(new FlatMapFunction<Vertex<String, VV>, Vertex<String, VV>>() {
+
+				@Override
+				public void flatMap(Vertex<String, VV> vertex, Collector<Vertex<String, VV>> collector) throws Exception {
+					int pos = vertex.getId().lastIndexOf("_");
+					if (pos >= 0 ) {
+						collector.collect(new Vertex<String, VV>(vertex.getId().substring(0, pos), vertex.getValue()));
+					} else {
+						collector.collect(vertex);
+					}
+				}
+			}).groupBy(0).reduceGroup(groupReduce);
+		}
+
+		return regularVertices.union(splitVertices);
+	}
+
+	private static final class  SplitSourceCoGroup<EV> implements
+			CoGroupFunction<Edge<String, EV>, Vertex<String, NullValue>, Edge<String, EV>> {
+
+		int currentLevel;
+		int alpha;
+
+		public SplitSourceCoGroup(int currentLevel, int alpha) {
+			this.currentLevel = currentLevel;
+			this.alpha = alpha;
+		}
+
+		@Override
+		public void coGroup(Iterable<Edge<String, EV>> iterableEdges,
+							Iterable<Vertex<String, NullValue>> iterableVertices,
+							Collector<Edge<String, EV>> collector) throws Exception {
+			Iterator<Vertex<String, NullValue>> vertexIterator = iterableVertices.iterator();
+			Iterator<Edge<String, EV>> edgeIterator = iterableEdges.iterator();
+
+			Vertex<String, NullValue> vertex = null;
+
+			if(vertexIterator.hasNext()) {
+				vertex = vertexIterator.next();
+			}
+
+			while(edgeIterator.hasNext()) {
+				Edge<String, EV> edge = edgeIterator.next();
+
+				int targetHashCode = edge.getTarget().hashCode();
+
+				// avoid having the same hash code from one level to the other
+				for(int i=0; i < currentLevel; i++) {
+					targetHashCode = Sha.hash256(targetHashCode + "").hashCode();
+				}
+				if(targetHashCode < 0) {
+					targetHashCode *= -1;
+				}
+				if(vertex != null) {
+					collector.collect(new Edge<String, EV>(vertex.getId() + "_" + targetHashCode % alpha,
+							edge.getTarget(), edge.getValue()));
+				} else {
+					collector.collect(edge);
+				}
+
+			}
+		}
+	}
+
+	private static final class SplitTargetCoGroup<EV> implements
+			CoGroupFunction<Edge<String, EV>, Vertex<String, NullValue>, Edge<String, EV>> {
+
+		int currentLevel;
+		int alpha;
+
+		public SplitTargetCoGroup(int currentLevel, int alpha) {
+			this.currentLevel = currentLevel;
+			this.alpha = alpha;
+		}
+
+		@Override
+		public void coGroup(Iterable<Edge<String, EV>> iterableEdges,
+							Iterable<Vertex<String, NullValue>> iterableVertices,
+							Collector<Edge<String, EV>> collector) throws Exception {
+
+			Iterator<Vertex<String, NullValue>> vertexIterator = iterableVertices.iterator();
+			Iterator<Edge<String, EV>> edgeIterator = iterableEdges.iterator();
+
+			Vertex<String, NullValue> vertex = null;
+
+			if(vertexIterator.hasNext()) {
+				vertex = vertexIterator.next();
+			}
+
+			while(edgeIterator.hasNext()) {
+				Edge<String, EV> edge = edgeIterator.next();
+
+				int sourceHashCode = edge.getSource().hashCode();
+
+				// avoid having the same hash code from one level to the other
+				for(int i=0; i < currentLevel; i++) {
+					sourceHashCode = Sha.hash256(sourceHashCode+"").hashCode();
+				}
+				if(sourceHashCode < 0) {
+					sourceHashCode *= -1;
+				}
+
+				if (vertex != null) {
+					collector.collect(new Edge<String, EV>(edge.getSource(),
+							vertex.getId() + "_" + sourceHashCode % alpha, edge.getValue()));
+				} else {
+					collector.collect(edge);
+				}
+			}
+		}
+	}
+
+	private static final class SplitVerticesCoGroup<VV> implements CoGroupFunction<Vertex<String, VV>, Vertex<String, NullValue>, Vertex<String, VV>> {
+
+		int alpha;
+
+		public SplitVerticesCoGroup(int alpha) {
+			this.alpha = alpha;
+		}
+
+
+		@Override
+		public void coGroup(Iterable<Vertex<String, VV>> vertex,
+							Iterable<Vertex<String, NullValue>> skewedVertex,
+							Collector<Vertex<String, VV>> collector) throws Exception {
+
+			Iterator<Vertex<String, VV>> vertexIterator = vertex.iterator();
+			Iterator<Vertex<String, NullValue>> skewedVertexIterator = skewedVertex.iterator();
+
+			Vertex<String, VV> next = null;
+
+			if (vertexIterator.hasNext()) {
+				if (!skewedVertexIterator.hasNext()) {
+					next = vertexIterator.next();
+					collector.collect(next);
+				} else {
+					next = vertexIterator.next();
+					for (int i = 0; i < alpha; i++) {
+						collector.collect(new Vertex<String, VV>(next.getId() + "_" + i, next.getValue()));
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Method that avoids performing a second treeDeAggregate when you just want to propagate the vertex
+	 * values to the splitted vertices.
+	 *
+	 * Another treeDeAggregate would just add overhead since the vertices and edges remain the same
+	 * and just the vertex values change.
+	 *
+	 * splitVertices will be joined with aggregatedVertices (via KeySelector) to return the id and the tag of
+	 * the splitVertex along with the value of the aggregated vertex.
+	 *
+	 * @param splitVertices
+	 * @param aggregatedVertices
+	 * @param <VV>
+	 * @return updated vertices
+	 */
+	public static <VV extends Serializable> DataSet<Vertex<String, Tuple2<String, VV>>> propagateValuesToSplitVertices(
+			DataSet<Vertex<String, Tuple2<String, VV>>> splitVertices,
+			DataSet<Vertex<String, VV>> aggregatedVertices) {
+
+		return splitVertices.join(aggregatedVertices)
+				.where(new KeySelector<Vertex<String, Tuple2<String, VV>>, String>() {
+					@Override
+					public String getKey(Vertex<String, Tuple2<String, VV>> vertex) throws Exception {
+						int pos = vertex.getId().indexOf("_");
+
+						if (pos > -1) {
+							return vertex.getId().substring(0, pos);
+						} else {
+							return vertex.getId();
+						}
+					}
+				}).equalTo(0).with(new JoinFunction<Vertex<String, Tuple2<String, VV>>,
+						Vertex<String, VV>, Vertex<String, Tuple2<String, VV>>>() {
+
+					@Override
+					public Vertex<String, Tuple2<String, VV>> join(Vertex<String, Tuple2<String, VV>> splitVertex,
+																   Vertex<String, VV> aggregatedVertex) throws Exception {
+						return new Vertex<String, Tuple2<String, VV>>(splitVertex.getId(),
+								new Tuple2<String, VV>(splitVertex.getValue().f0, aggregatedVertex.getValue()));
+					}
+				});
+	}
+}

--- a/src/main/java/util/JaccardSimilarityMeasureData.java
+++ b/src/main/java/util/JaccardSimilarityMeasureData.java
@@ -10,30 +10,30 @@ import java.util.List;
 
 public class JaccardSimilarityMeasureData {
 
-	public static final Integer MAX_ITERATIONS = 1;
+	public static final String EDGES = "1	2\n" + "1	7\n" + "2	7\n" + "3	4\n" + "3	7\n" + "4	7\n" +
+			"5	6\n" + "5	7\n" + "6	7\n" + "7	8";
 
-	public static final String EDGES = "1	2\n" + "1	3\n" + "1	4\n" + "1	5\n" + "2	3\n" + "2	4\n" +
-			"2	5\n" + "3	4\n" + "3	5\n" + "4	5";
+	public static DataSet<Edge<String, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-	public static DataSet<Edge<Long, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
-
-		List<Edge<Long, NullValue>> edges = new ArrayList<>();
-		edges.add(new Edge<Long, NullValue>(1L, 2L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(1L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(1L, 4L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(1L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 4L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(3L, 4L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(3L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(4L, 5L, NullValue.getInstance()));
+		List<Edge<String, NullValue>> edges = new ArrayList<>();
+		edges.add(new Edge<String, NullValue>("1", "2", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("1", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("2", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("3", "4", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("3", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("4", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("5", "6", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("5", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("6", "7", NullValue.getInstance()));
+		edges.add(new Edge<String, NullValue>("7", "8", NullValue.getInstance()));
 
 		return env.fromCollection(edges);
 	}
 
-	public static final String JACCARD_VERTICES = "1,{2=0.6, 3=0.6, 4=0.6, 5=0.6}\n" + "2,{1=0.6, 3=0.6, 4=0.6, 5=0.6}\n"
-			+"3,{1=0.6, 2=0.6, 4=0.6, 5=0.6}\n" + "4,{1=0.6, 2=0.6, 3=0.6, 5=0.6}\n" + "5,{1=0.6, 2=0.6, 3=0.6, 4=0.6}";
+	public static final String JACCARD_VERTICES = "1,{2=0.3333333333333333, 7=0.125}\n" + "2,{1=0.3333333333333333, 7=0.125}\n"
+			+"3,{4=0.3333333333333333, 7=0.125}\n" + "4,{3=0.3333333333333333, 7=0.125}\n" + "5,{6=0.3333333333333333, 7=0.125}\n"
+			+"6,{5=0.3333333333333333, 7=0.125}\n" + "7,{1=0.125, 2=0.125, 3=0.125, 4=0.125, 5=0.125, 6=0.125, 8=0.0}\n"
+			+"8,{7=0.0}";
 
 
 	private JaccardSimilarityMeasureData() {}

--- a/src/test/java/example/JaccardSimilarityMeasureITCase.java
+++ b/src/test/java/example/JaccardSimilarityMeasureITCase.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import util.JaccardSimilarityMeasureData;
+import util.NodeSplittingData;
 
 import java.io.File;
 
@@ -42,7 +43,7 @@ public class JaccardSimilarityMeasureITCase extends MultipleProgramsTestBase {
 
 	@Test
 	public void testJaccardSimilarityMeasureExample() throws Exception {
-		JaccardSimilarityMeasure.main(new String[]{edgesPath, resultPath});
+		NodeSplittingJaccard.main(new String[]{edgesPath, resultPath, NodeSplittingData.ALPHA + "", NodeSplittingData.LEVEL + ""});
 		expected = JaccardSimilarityMeasureData.JACCARD_VERTICES;
 	}
 


### PR DESCRIPTION
This is an implementation of the Jaccard similarity metric algorithm with node splitting. 

Subvertices are tagged, they do a partial computation and then their results are combined to form the final result in the initial, skewed vertex. 
A high level description can be found here [Solution 2]: 
https://docs.google.com/presentation/d/10bW88GD0seNLLvkk9fD41Y5Jbn842tWa_u0f5hhJfME/edit#slide=id.p

---

The methods that stay the same for any algorithm are in splitUtils/SplitVertex. 
What changes is the function used for combining as @asteriosk observed at some point. This will be provided by the user.

---

@vasia , I believe this implementation covers the overlapping neighbourhoods "issue" due to the way the edges are distributed to the subvertices. But, please have a closer look and let me know :) 

---

Tests: CLUSTER mode fails with a known Flink issue. 
