### PR TITLE
First Step Towards Graph Partitioning

### DIFF
--- a/src/main/java/degrees/Degrees.java
+++ b/src/main/java/degrees/Degrees.java
@@ -1,0 +1,81 @@
+package degrees;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.types.NullValue;
+import util.NodeSplittingData;
+
+public class Degrees {
+
+	public static void main(String [] args) throws Exception {
+		if (!parseParameters(args)) {
+			return;
+		}
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<String, NullValue>> edges = getEdgesDataSet(env);
+		Graph<String, NullValue, NullValue> graph = Graph.fromDataSet(edges, env);
+
+		DataSet<Tuple2<String, Long>> degrees = graph.getDegrees();
+
+		// emit result
+		if (fileOutput) {
+			degrees.writeAsCsv(outputPath, "\n", " ");
+			env.execute("Executing Jaccard Similarity Measure");
+		} else {
+			degrees.print();
+		}
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+
+	private static boolean parseParameters(String [] args) {
+		if(args.length > 0) {
+			if(args.length != 2) {
+				System.err.println("Usage Degrees <edge path> <output path>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+		} else {
+			System.out.println("Executing Degrees with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage Degrees <edge path> <output path>");
+		}
+
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<String, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+
+		if(fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
+						@Override
+						public Edge<String, NullValue> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return NodeSplittingData.getDefaultEdgeDataSet(env);
+		}
+	}
+}

--- a/src/main/java/degrees/Degrees.java
+++ b/src/main/java/degrees/Degrees.java
@@ -65,7 +65,7 @@ public class Degrees {
 		if(fileOutput) {
 			return env.readCsvFile(edgeInputPath)
 					.ignoreComments("#")
-					.fieldDelimiter("\t")
+					.fieldDelimiter(" ")
 					.lineDelimiter("\n")
 					.types(String.class, String.class)
 					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {

--- a/src/main/java/example/GSAConnectedComponents.java
+++ b/src/main/java/example/GSAConnectedComponents.java
@@ -7,10 +7,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.gsa.ApplyFunction;
-import org.apache.flink.graph.gsa.GatherFunction;
-import org.apache.flink.graph.gsa.Neighbor;
-import org.apache.flink.graph.gsa.SumFunction;
+import org.apache.flink.graph.gsa.*;
 import org.apache.flink.types.NullValue;
 import util.ConnectedComponentsData;
 
@@ -33,10 +30,13 @@ public class GSAConnectedComponents implements ProgramDescription {
 			}
 		}, env);
 
+		GSAConfiguration parameters = new GSAConfiguration();
+		parameters.setSolutionSetUnmanagedMemory(true);
+
 		// Execute the GSA iteration
 		Graph<String, String, NullValue> result =
 				graph.runGatherSumApplyIteration(new GatherNeighborIds(), new SelectMinId(),
-						new UpdateComponentId(), maxIterations);
+						new UpdateComponentId(), maxIterations, parameters);
 
 		// emit result
 		if (fileOutput) {
@@ -122,6 +122,7 @@ public class GSAConnectedComponents implements ProgramDescription {
 	private static DataSet<Edge<String, NullValue>> getEdgeDataSet(ExecutionEnvironment env) {
 		if (fileOutput) {
 			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
 					.types(String.class, String.class)

--- a/src/main/java/example/GSAJaccardSimilarityMeasure.java
+++ b/src/main/java/example/GSAJaccardSimilarityMeasure.java
@@ -10,6 +10,7 @@ import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.NullValue;
+import util.DummyGraph;
 import util.JaccardSimilarityMeasureData;
 
 import java.util.HashSet;
@@ -50,8 +51,8 @@ public class GSAJaccardSimilarityMeasure implements ProgramDescription {
 		DataSet<Vertex<String, HashSet<String>>> verticesWithNeighbors =
 				GSAJaccard.attachValuesToVertices(graph, computedNeighbors);
 
-		Graph<String, HashSet<String>, NullValue> graphWithNeighbors =
-				Graph.fromDataSet(verticesWithNeighbors, edges, env);
+		DummyGraph<String, HashSet<String>, NullValue> graphWithNeighbors =
+				DummyGraph.fromDataSet(verticesWithNeighbors, edges, env);
 
 		// Scatter: compare neighbors; compute Jaccard
 		DataSet<Edge<String, Double>> edgesWithJaccardValues =

--- a/src/main/java/example/NodeSplittingGSAConnectedComponents.java
+++ b/src/main/java/example/NodeSplittingGSAConnectedComponents.java
@@ -240,6 +240,7 @@ public class NodeSplittingGSAConnectedComponents implements ProgramDescription {
 	private static DataSet<Edge<String, NullValue>> getEdgeDataSet(ExecutionEnvironment env) {
 		if (fileOutput) {
 			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
 					.types(String.class, String.class)

--- a/src/main/java/example/debug/ReadGenGraph.java
+++ b/src/main/java/example/debug/ReadGenGraph.java
@@ -1,0 +1,103 @@
+package example.debug;
+
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import util.CommunityDetectionData;
+
+public class ReadGenGraph implements ProgramDescription {
+
+	public static void main (String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		// set up the execution environment
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		// set up the graph
+		DataSet<Edge<String, Double>> edges = getEdgesDataSet(env);
+		Graph<String, Long, Double> graph = Graph.fromDataSet(edges,
+				new StringToLongMap(), env);
+
+		// emit result
+		if (fileOutput) {
+			graph.getVertices().writeAsCsv(outputPath, "\n", ",");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("Executing Community Detection Example");
+		} else {
+			graph.getVertices().print();
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return "Read Generated Graph";
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+	private static Integer maxIterations = CommunityDetectionData.MAX_ITERATIONS;
+	private static Double delta = CommunityDetectionData.DELTA;
+
+	private static boolean parseParameters(String [] args) {
+		if(args.length > 0) {
+			if(args.length != 4) {
+				System.err.println("Usage CommunityDetection <edge path> <output path> " +
+						"<num iterations> <delta>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+			maxIterations = Integer.parseInt(args[2]);
+			delta = Double.parseDouble(args[3]);
+		} else {
+			System.out.println("Executing SimpleCommunityDetection example with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage CommunityDetection <edge path> <output path> " +
+					"<num iterations> <delta>");
+		}
+		return true;
+	}
+
+	private static DataSet<Edge<String, Double>> getEdgesDataSet(ExecutionEnvironment env) {
+		if(fileOutput) {
+
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, Double>>() {
+						@Override
+						public Edge<String, Double> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, Double>(tuple2.f0, tuple2.f1, 3.0);
+						}
+					});
+		} else {
+			return CommunityDetectionData.getDefaultEdgeDataSet(env);
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class StringToLongMap implements MapFunction<String, Long> {
+
+		@Override
+		public Long map(String s) throws Exception {
+			return Long.parseLong(s);
+		}
+	}
+}

--- a/src/main/java/library/CommunityDetection.java
+++ b/src/main/java/library/CommunityDetection.java
@@ -8,6 +8,7 @@ import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.spargel.MessageIterator;
 import org.apache.flink.graph.spargel.MessagingFunction;
+import org.apache.flink.graph.spargel.VertexCentricConfiguration;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 
 import java.util.Map;
@@ -42,8 +43,12 @@ public class CommunityDetection implements GraphAlgorithm<String, Long, Double> 
 		Graph<String, Long, Double> undirectedGraph = graph.getUndirected();
 		Graph<String, Tuple2<Long, Double>, Double> graphWithScoredVertices = undirectedGraph
 				.mapVertices(new AddScoreToVertexValuesMapper());
+
+		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		parameters.setSolutionSetUnmanagedMemory(true);
+
 		return graphWithScoredVertices.runVertexCentricIteration(new VertexLabelUpdater(delta),
-				new LabelMessenger(), maxIterations)
+				new LabelMessenger(), maxIterations, parameters)
 				.mapVertices(new RemoveScoreFromVertexValuesMapper());
 	}
 

--- a/src/main/java/library/ConnectedComponentsAlgorithm.java
+++ b/src/main/java/library/ConnectedComponentsAlgorithm.java
@@ -5,6 +5,7 @@ import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.spargel.MessageIterator;
 import org.apache.flink.graph.spargel.MessagingFunction;
+import org.apache.flink.graph.spargel.VertexCentricConfiguration;
 import org.apache.flink.graph.spargel.VertexUpdateFunction;
 import org.apache.flink.types.NullValue;
 
@@ -32,9 +33,12 @@ public class ConnectedComponentsAlgorithm implements GraphAlgorithm<String, Long
 
 		Graph<String, Long, NullValue> undirectedGraph = graph.getUndirected();
 
+		VertexCentricConfiguration parameters = new VertexCentricConfiguration();
+		parameters.setSolutionSetUnmanagedMemory(true);
+
 		// initialize vertex values and run the Vertex Centric Iteration
 		return undirectedGraph.runVertexCentricIteration(new CCUpdater(),
-				new CCMessenger(), maxIterations);
+				new CCMessenger(), maxIterations, parameters);
 	}
 
 	/**

--- a/src/main/java/library/GSAJaccard.java
+++ b/src/main/java/library/GSAJaccard.java
@@ -57,7 +57,7 @@ public class GSAJaccard {
 	}
 
 	public static DataSet<Edge<String, Double>> computeJaccard
-			(Graph<String, HashSet<String>, NullValue> graphWithNeighbors) {
+			(DummyGraph<String, HashSet<String>, NullValue> graphWithNeighbors) {
 
 		return graphWithNeighbors.getTriplets().map(new ComputeJaccard());
 	}

--- a/src/main/java/partitioning/MirroredExample.java
+++ b/src/main/java/partitioning/MirroredExample.java
@@ -1,0 +1,98 @@
+package partitioning;
+
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import util.NodeSplittingData;
+
+/**
+ * A mirror of the partitioning example - same operations; no custom partitioning
+ */
+public class MirroredExample {
+
+	public static void main (String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<String, NullValue>> edges = getEdgesDataSet(env);
+		Graph<String, NullValue, NullValue> graph = Graph.fromDataSet(edges, env);
+
+		DataSet<Edge<String, NullValue>> joinedEdges = edges.join(graph.getVertices())
+				.where(0).equalTo(0).with(new FlatJoinFunction<Edge<String, NullValue>, Vertex<String, NullValue>, Edge<String, NullValue>>() {
+					@Override
+					public void join(Edge<String, NullValue> edge,
+									 Vertex<String, NullValue> vertex,
+									 Collector<Edge<String, NullValue>> collector) throws Exception {
+
+						collector.collect(edge);
+					}
+				});
+
+		// emit result
+		if(fileOutput) {
+			joinedEdges.writeAsCsv(outputPath, "\n", ",");
+			env.execute("Executing mirrored Example");
+		} else {
+			joinedEdges.print();
+		}
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+
+	private static boolean parseParameters(String[] args) {
+		if (args.length > 0) {
+			if (args.length != 2) {
+				System.err.println("Usage MirroredExample <edge path> <output path>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+		} else {
+			System.out.println("Executing PartitioningExample with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage MirroredExample <edge path> <output path>");
+		}
+
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<String, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+
+		if (fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
+						@Override
+						public Edge<String, NullValue> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return NodeSplittingData.getDefaultEdgeDataSet(env);
+
+		}
+	}
+}

--- a/src/main/java/partitioning/PartitionedCustomGSAConnectedComponents.java
+++ b/src/main/java/partitioning/PartitionedCustomGSAConnectedComponents.java
@@ -1,0 +1,143 @@
+package partitioning;
+
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.types.NullValue;
+import partitioning.gsa.*;
+import util.ConnectedComponentsData;
+import util.DummyGraph;
+import util.NodeSplittingData;
+
+public class PartitionedCustomGSAConnectedComponents implements ProgramDescription{
+
+	public static void main (String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<String, NullValue>> edges = getEdgeDataSet(env);
+
+		DummyGraph<String, String, NullValue> graph = DummyGraph.fromDataSet(edges, new MapFunction<String, String>() {
+			@Override
+			public String map(String s) throws Exception {
+				return s;
+			}
+		}, env);
+
+		GSAConfiguration parameters = new GSAConfiguration();
+		parameters.setSolutionSetUnmanagedMemory(true);
+		parameters.setCustomPartition(true);
+
+		// Execute the GSA iteration
+		DummyGraph<String, String, NullValue> result =
+				graph.runGatherSumApplyIteration(new GatherNeighborIds(), new SelectMinId(),
+						new UpdateComponentId(), maxIterations, threshold, parameters);
+
+		// emit result
+		if (fileOutput) {
+			result.getVertices().writeAsCsv(outputPath, "\n", " ");
+
+			// since file sinks are lazy, we trigger the execution explicitly
+			env.execute("GSA Connected Components - Custom Partitioned");
+		} else {
+			result.getVertices().print();
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Connected Components UDFs
+	// --------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("serial")
+	private static final class GatherNeighborIds extends GatherFunction<String, NullValue, String> {
+
+		public String gather(Neighbor<String, NullValue> neighbor) {
+			return neighbor.getNeighborValue();
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class SelectMinId extends SumFunction<String, NullValue, String> {
+
+		public String sum(String newValue, String currentValue) {
+			return Math.min(Long.parseLong(newValue), Long.parseLong(currentValue)) + "";
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class UpdateComponentId extends ApplyFunction<String, String, String> {
+
+		public void apply(String summedValue, String origValue) {
+			if (Long.parseLong(summedValue) < Long.parseLong(origValue)) {
+				setResult(summedValue);
+			}
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return "Partition Custom GSA Connected Components";
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Util methods
+	// --------------------------------------------------------------------------------------------
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+
+	private static int maxIterations = ConnectedComponentsData.MAX_ITERATIONS;
+	private static int threshold = NodeSplittingData.THRESHOLD;
+
+	private static boolean parseParameters(String [] args) {
+
+		if (args.length > 0) {
+			// parse input arguments
+			fileOutput = true;
+
+			if (args.length != 4) {
+				System.err.println("Usage: GSAConnectedComponents <edge path> " +
+						"<result path> <max iterations> <threshold>");
+				return false;
+			}
+
+			edgeInputPath = args[0];
+			outputPath = args[1];
+			maxIterations = Integer.parseInt(args[2]);
+			threshold = Integer.parseInt(args[3]);
+		} else {
+			System.out.println("Executing GSA Connected Components example with built-in default data.");
+			System.out.println("  Provide parameters to read input data from files.");
+			System.out.println("  See the documentation for the correct format of input files.");
+			System.out.println("  Usage: GSAConnectedComponents <edge path> <result path> <max iterations> <threshold>");
+		}
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<String, NullValue>> getEdgeDataSet(ExecutionEnvironment env) {
+		if (fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
+
+						public Edge<String, NullValue> map(Tuple2<String, String> value) throws Exception {
+							return new Edge<String, NullValue>(value.f0, value.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return ConnectedComponentsData.getDefaultEdgeDataSet(env);
+		}
+	}
+}

--- a/src/main/java/partitioning/PartitioningExample.java
+++ b/src/main/java/partitioning/PartitioningExample.java
@@ -1,0 +1,139 @@
+package partitioning;
+
+import org.apache.flink.api.common.functions.FlatJoinFunction;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import splitUtils.SplitVertex;
+import util.NodeSplittingData;
+
+public class PartitioningExample {
+
+	public static void main(String [] args) throws Exception {
+
+		if(!parseParameters(args)) {
+			return;
+		}
+
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		DataSet<Edge<String, NullValue>> edges = getEdgesDataSet(env);
+		Graph<String, NullValue, NullValue> graph = Graph.fromDataSet(edges, env);
+
+		// discover the skewed nodes
+		DataSet<Tuple2<String, Long>> verticesWithDegrees = graph.getDegrees();
+
+		DataSet<Vertex<String, NullValue>> skewedVertices = SplitVertex.determineSkewedVertices(threshold,
+				verticesWithDegrees);
+
+		DataSet<Vertex<String, NullValue>> unskewedVertices = determineUnskewedVertices(threshold,
+				verticesWithDegrees);
+
+		DataSet<Edge<String, NullValue>> joinedEdges;
+
+		// compute a data set of joinedEdges for skewed vertices, with vertex-cut partitioning
+		DataSet<Edge<String, NullValue>> joinedEdgesSkewed = edges.join(skewedVertices)
+				.where(0).equalTo(0).with(new CollectEdge()).partitionCustom(new SourcePartition(), 1);
+
+		// and a data set of joinedEdges for regular vertices, with edge-cut partitioning
+		DataSet<Edge<String, NullValue>> joinedEdgesUnskewed = edges.join(unskewedVertices)
+				.where(0).equalTo(0).with(new CollectEdge()).partitionCustom(new TargetPartition(), 0);
+
+		// union the data sets to get the final result
+		joinedEdges = joinedEdgesSkewed.union(joinedEdgesUnskewed);
+
+		// emit result
+		if(fileOutput) {
+			joinedEdges.writeAsCsv(outputPath, "\n", ",");
+			env.execute("Executing partitioning Example");
+		} else {
+			joinedEdges.print();
+		}
+
+	}
+
+	public static DataSet<Vertex<String, NullValue>> determineUnskewedVertices(final double xMin,
+																			 DataSet<Tuple2<String, Long>> verticesWithDegrees) throws Exception {
+		return verticesWithDegrees
+				.flatMap(new FlatMapFunction<Tuple2<String, Long>, Vertex<String, NullValue>>() {
+
+					@Override
+					public void flatMap(Tuple2<String, Long> vertexIdDegree,
+										Collector<Vertex<String, NullValue>> collector) throws Exception {
+						if(vertexIdDegree.f1 <= xMin) {
+							collector.collect(new Vertex<String, NullValue>(vertexIdDegree.f0, NullValue.getInstance()));
+						}
+					}
+				});
+	}
+
+	public static final class CollectEdge implements FlatJoinFunction<Edge<String, NullValue>,
+			Vertex<String, NullValue>, Edge<String, NullValue>> {
+
+		@Override
+		public void join(Edge<String, NullValue> edge,
+						 Vertex<String, NullValue> vertex,
+						 Collector<Edge<String, NullValue>> collector) throws Exception {
+
+			collector.collect(edge);
+		}
+	}
+
+	// *************************************************************************
+	// UTIL METHODS
+	// *************************************************************************
+
+	private static boolean fileOutput = false;
+	private static String edgeInputPath = null;
+	private static String outputPath = null;
+
+	private static Integer threshold = NodeSplittingData.THRESHOLD;
+
+	private static boolean parseParameters(String[] args) {
+		if (args.length > 0) {
+			if (args.length != 3) {
+				System.err.println("Usage PartitioningExample <edge path> <output path> <threshold>");
+				return false;
+			}
+
+			fileOutput = true;
+			edgeInputPath = args[0];
+			outputPath = args[1];
+			threshold = Integer.parseInt(args[2]);
+		} else {
+			System.out.println("Executing PartitioningExample with default parameters and built-in default data.");
+			System.out.println("Provide parameters to read input data from files.");
+			System.out.println("Usage PartitioningExample <edge path> <output path> <threshold>");
+		}
+
+		return true;
+	}
+
+	@SuppressWarnings("serial")
+	private static DataSet<Edge<String, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+
+		if (fileOutput) {
+			return env.readCsvFile(edgeInputPath)
+					.ignoreComments("#")
+					.fieldDelimiter("\t")
+					.lineDelimiter("\n")
+					.types(String.class, String.class)
+					.map(new MapFunction<Tuple2<String, String>, Edge<String, NullValue>>() {
+						@Override
+						public Edge<String, NullValue> map(Tuple2<String, String> tuple2) throws Exception {
+							return new Edge<String, NullValue>(tuple2.f0, tuple2.f1, NullValue.getInstance());
+						}
+					});
+		} else {
+			return NodeSplittingData.getDefaultEdgeDataSet(env);
+
+		}
+	}
+}

--- a/src/main/java/partitioning/SourcePartition.java
+++ b/src/main/java/partitioning/SourcePartition.java
@@ -1,0 +1,11 @@
+package partitioning;
+
+import org.apache.flink.api.common.functions.Partitioner;
+
+public class SourcePartition implements Partitioner<String> {
+	
+	@Override
+	public int partition(String source, int numPartitions) {
+		return (int) Long.parseLong(source) % numPartitions;
+	}
+}

--- a/src/main/java/partitioning/TargetPartition.java
+++ b/src/main/java/partitioning/TargetPartition.java
@@ -1,0 +1,11 @@
+package partitioning;
+
+import org.apache.flink.api.common.functions.Partitioner;
+
+public class TargetPartition implements Partitioner<String> {
+
+	@Override
+	public int partition(String target, int numpartitions) {
+		return (int) Long.parseLong(target) % numpartitions;
+	}
+}

--- a/src/main/java/partitioning/gsa/ApplyFunction.java
+++ b/src/main/java/partitioning/gsa/ApplyFunction.java
@@ -1,0 +1,122 @@
+package partitioning.gsa;
+
+import org.apache.flink.api.common.aggregators.Aggregator;
+import org.apache.flink.api.common.functions.IterationRuntimeContext;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.Value;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+@SuppressWarnings("serial")
+public abstract class ApplyFunction<K, VV, M> implements Serializable {
+
+	// --------------------------------------------------------------------------------------------
+	//  Attribute that allows access to the total number of vertices inside an iteration.
+	// --------------------------------------------------------------------------------------------
+
+	private long numberOfVertices = -1L;
+
+	/**
+	 * Retrieves the number of vertices in the graph.
+	 * @return the number of vertices if the {@link IterationConfigurationion#setOptNumVertices(boolean)}
+	 * option has been set; -1 otherwise.
+	 */
+	public long getNumberOfVertices() {
+		return numberOfVertices;
+	}
+
+	void setNumberOfVertices(long numberOfVertices) {
+		this.numberOfVertices = numberOfVertices;
+	}
+
+	//---------------------------------------------------------------------------------------------
+
+	public abstract void apply(M newValue, VV currentValue);
+
+	/**
+	 * Sets the result for the apply function
+	 *
+	 * @param result the result of the apply phase
+	 */
+	public void setResult(VV result) {
+		outVal.f1 = result;
+		out.collect(outVal);
+	}
+
+	/**
+	 * This method is executed once per superstep before the vertex update function is invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the pre-superstep phase cause the superstep to fail.
+	 */
+	public void preSuperstep() {}
+
+	/**
+	 * This method is executed once per superstep after the vertex update function has been invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the post-superstep phase cause the superstep to fail.
+	 */
+	public void postSuperstep() {}
+
+	/**
+	 * Gets the number of the superstep, starting at <tt>1</tt>.
+	 *
+	 * @return The number of the current superstep.
+	 */
+	public int getSuperstepNumber() {
+		return this.runtimeContext.getSuperstepNumber();
+	}
+
+	/**
+	 * Gets the iteration aggregator registered under the given name. The iteration aggregator combines
+	 * all aggregates globally once per superstep and makes them available in the next superstep.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregator registered under this name, or null, if no aggregator was registered.
+	 */
+	public <T extends Aggregator<?>> T getIterationAggregator(String name) {
+		return this.runtimeContext.<T>getIterationAggregator(name);
+	}
+
+	/**
+	 * Get the aggregated value that an aggregator computed in the previous iteration.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregated value of the previous iteration.
+	 */
+	public <T extends Value> T getPreviousIterationAggregate(String name) {
+		return this.runtimeContext.<T>getPreviousIterationAggregate(name);
+	}
+
+	/**
+	 * Gets the broadcast data set registered under the given name. Broadcast data sets
+	 * are available on all parallel instances of a function.
+	 *
+	 * @param name The name under which the broadcast set is registered.
+	 * @return The broadcast data set.
+	 */
+	public <T> Collection<T> getBroadcastSet(String name) {
+		return this.runtimeContext.<T>getBroadcastVariable(name);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Internal methods
+	// --------------------------------------------------------------------------------------------
+
+	private IterationRuntimeContext runtimeContext;
+
+	private Collector<Vertex<K, VV>> out;
+
+	private Vertex<K, VV> outVal;
+
+	public void init(IterationRuntimeContext iterationRuntimeContext) {
+		this.runtimeContext = iterationRuntimeContext;
+	}
+
+	public void setOutput(Vertex<K, VV> vertex, Collector<Vertex<K, VV>> out) {
+		this.out = out;
+		this.outVal = vertex;
+	}
+
+}

--- a/src/main/java/partitioning/gsa/GSAConfiguration.java
+++ b/src/main/java/partitioning/gsa/GSAConfiguration.java
@@ -1,0 +1,103 @@
+package partitioning.gsa;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.IterationConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A GSAConfiguration object can be used to set the iteration name and
+ * degree of parallelism, to register aggregators and use broadcast sets in
+ * the {@link org.apache.flink.graph.gsa.GatherFunction}, {@link org.apache.flink.graph.gsa.SumFunction} as well as
+ * {@link org.apache.flink.graph.gsa.ApplyFunction}.
+ *
+ * The GSAConfiguration object is passed as an argument to
+ * {@link org.apache.flink.graph.Graph#runGatherSumApplyIteration(org.apache.flink.graph.gsa.GatherFunction,
+ * org.apache.flink.graph.gsa.SumFunction, org.apache.flink.graph.gsa.ApplyFunction, int)}
+ */
+public class GSAConfiguration extends IterationConfiguration {
+
+	/** the broadcast variables for the gather function **/
+	private List<Tuple2<String, DataSet<?>>> bcVarsGather = new ArrayList<Tuple2<String,DataSet<?>>>();
+
+	/** the broadcast variables for the sum function **/
+	private List<Tuple2<String, DataSet<?>>> bcVarsSum = new ArrayList<Tuple2<String,DataSet<?>>>();
+
+	/** the broadcast variables for the apply function **/
+	private List<Tuple2<String, DataSet<?>>> bcVarsApply = new ArrayList<Tuple2<String,DataSet<?>>>();
+
+	private boolean customPartition = false;
+
+	public GSAConfiguration() {}
+
+	/**
+	 * Adds a data set as a broadcast set to the gather function.
+	 *
+	 * @param name The name under which the broadcast data is available in the gather function.
+	 * @param data The data set to be broadcasted.
+	 */
+	public void addBroadcastSetForGatherFunction(String name, DataSet<?> data) {
+		this.bcVarsGather.add(new Tuple2<String, DataSet<?>>(name, data));
+	}
+
+	/**
+	 * Adds a data set as a broadcast set to the sum function.
+	 *
+	 * @param name The name under which the broadcast data is available in the sum function.
+	 * @param data The data set to be broadcasted.
+	 */
+	public void addBroadcastSetForSumFunction(String name, DataSet<?> data) {
+		this.bcVarsSum.add(new Tuple2<String, DataSet<?>>(name, data));
+	}
+
+	/**
+	 * Adds a data set as a broadcast set to the apply function.
+	 *
+	 * @param name The name under which the broadcast data is available in the apply function.
+	 * @param data The data set to be broadcasted.
+	 */
+	public void addBroadcastSetForApplyFunction(String name, DataSet<?> data) {
+		this.bcVarsApply.add(new Tuple2<String, DataSet<?>>(name, data));
+	}
+
+	/**
+	 * Get the broadcast variables of the GatherFunction.
+	 *
+	 * @return a List of Tuple2, where the first field is the broadcast variable name
+	 * and the second field is the broadcast DataSet.
+	 */
+	public List<Tuple2<String, DataSet<?>>> getGatherBcastVars() {
+		return this.bcVarsGather;
+	}
+
+	/**
+	 * Get the broadcast variables of the SumFunction.
+	 *
+	 * @return a List of Tuple2, where the first field is the broadcast variable name
+	 * and the second field is the broadcast DataSet.
+	 */
+	public List<Tuple2<String, DataSet<?>>> getSumBcastVars() {
+		return this.bcVarsSum;
+	}
+
+	/**
+	 * Get the broadcast variables of the ApplyFunction.
+	 *
+	 * @return a List of Tuple2, where the first field is the broadcast variable name
+	 * and the second field is the broadcast DataSet.
+	 */
+	public List<Tuple2<String, DataSet<?>>> getApplyBcastVars() {
+		return this.bcVarsApply;
+	}
+
+	public boolean isCustomPartition() {
+		return customPartition;
+	}
+
+	public void setCustomPartition(boolean customPartition) {
+		this.customPartition = customPartition;
+	}
+}
+

--- a/src/main/java/partitioning/gsa/GatherFunction.java
+++ b/src/main/java/partitioning/gsa/GatherFunction.java
@@ -1,0 +1,101 @@
+package partitioning.gsa;
+
+import org.apache.flink.api.common.aggregators.Aggregator;
+import org.apache.flink.api.common.functions.IterationRuntimeContext;
+import org.apache.flink.types.Value;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+@SuppressWarnings("serial")
+public abstract class GatherFunction<VV, EV, M> implements Serializable {
+
+	// --------------------------------------------------------------------------------------------
+	//  Attribute that allows access to the total number of vertices inside an iteration.
+	// --------------------------------------------------------------------------------------------
+
+	private long numberOfVertices = -1L;
+
+	/**
+	 * Retrieves the number of vertices in the graph.
+	 * @return the number of vertices if the {@link IterationConfigurationion#setOptNumVertices(boolean)}
+	 * option has been set; -1 otherwise.
+	 */
+	public long getNumberOfVertices() {
+		return numberOfVertices;
+	}
+
+	void setNumberOfVertices(long numberOfVertices) {
+		this.numberOfVertices = numberOfVertices;
+	}
+
+	//---------------------------------------------------------------------------------------------
+
+	public abstract M gather(Neighbor<VV, EV> neighbor);
+
+	/**
+	 * This method is executed once per superstep before the vertex update function is invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the pre-superstep phase cause the superstep to fail.
+	 */
+	public void preSuperstep() {}
+
+	/**
+	 * This method is executed once per superstep after the vertex update function has been invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the post-superstep phase cause the superstep to fail.
+	 */
+	public void postSuperstep() {}
+
+	/**
+	 * Gets the number of the superstep, starting at <tt>1</tt>.
+	 *
+	 * @return The number of the current superstep.
+	 */
+	public int getSuperstepNumber() {
+		return this.runtimeContext.getSuperstepNumber();
+	}
+
+	/**
+	 * Gets the iteration aggregator registered under the given name. The iteration aggregator combines
+	 * all aggregates globally once per superstep and makes them available in the next superstep.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregator registered under this name, or null, if no aggregator was registered.
+	 */
+	public <T extends Aggregator<?>> T getIterationAggregator(String name) {
+		return this.runtimeContext.<T>getIterationAggregator(name);
+	}
+
+	/**
+	 * Get the aggregated value that an aggregator computed in the previous iteration.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregated value of the previous iteration.
+	 */
+	public <T extends Value> T getPreviousIterationAggregate(String name) {
+		return this.runtimeContext.<T>getPreviousIterationAggregate(name);
+	}
+
+	/**
+	 * Gets the broadcast data set registered under the given name. Broadcast data sets
+	 * are available on all parallel instances of a function.
+	 *
+	 * @param name The name under which the broadcast set is registered.
+	 * @return The broadcast data set.
+	 */
+	public <T> Collection<T> getBroadcastSet(String name) {
+		return this.runtimeContext.<T>getBroadcastVariable(name);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Internal methods
+	// --------------------------------------------------------------------------------------------
+
+	private IterationRuntimeContext runtimeContext;
+
+	public void init(IterationRuntimeContext iterationRuntimeContext) {
+		this.runtimeContext = iterationRuntimeContext;
+	}
+}
+

--- a/src/main/java/partitioning/gsa/GatherSumApplyIteration.java
+++ b/src/main/java/partitioning/gsa/GatherSumApplyIteration.java
@@ -1,0 +1,478 @@
+package partitioning.gsa;
+
+import com.google.common.base.Preconditions;
+import org.apache.flink.api.common.aggregators.Aggregator;
+import org.apache.flink.api.common.functions.*;
+import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.common.operators.base.JoinOperatorBase;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.api.java.operators.*;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import util.NodeSplittingData;
+
+import java.util.Map;
+
+/**
+ * This class represents iterative graph computations, programmed in a gather-sum-apply perspective.
+ *
+ * @param <K> The type of the vertex key in the graph
+ * @param <VV> The type of the vertex value in the graph
+ * @param <EV> The type of the edge value in the graph
+ * @param <M> The intermediate type used by the gather, sum and apply functions
+ */
+public class GatherSumApplyIteration<K, VV, EV, M> implements CustomUnaryOperation<Vertex<K, VV>,
+		Vertex<K, VV>> {
+
+	private DataSet<Vertex<K, VV>> vertexDataSet;
+	private DataSet<Edge<K, EV>> edgeDataSet;
+
+	private final GatherFunction<VV, EV, M> gather;
+	private final SumFunction<VV, EV, M> sum;
+	private final ApplyFunction<K, VV, M> apply;
+	private final int maximumNumberOfIterations;
+	private int threshold = NodeSplittingData.THRESHOLD;
+
+	private GSAConfiguration configuration;
+
+	// ----------------------------------------------------------------------------------
+
+	private GatherSumApplyIteration(GatherFunction<VV, EV, M> gather, SumFunction<VV, EV, M> sum,
+									ApplyFunction<K, VV, M> apply, DataSet<Edge<K, EV>> edges, int maximumNumberOfIterations) {
+
+		Preconditions.checkNotNull(gather);
+		Preconditions.checkNotNull(sum);
+		Preconditions.checkNotNull(apply);
+		Preconditions.checkNotNull(edges);
+		Preconditions.checkArgument(maximumNumberOfIterations > 0, "The maximum number of iterations must be at least one.");
+
+
+		this.gather = gather;
+		this.sum = sum;
+		this.apply = apply;
+		this.edgeDataSet = edges;
+		this.maximumNumberOfIterations = maximumNumberOfIterations;
+	}
+
+	private GatherSumApplyIteration(GatherFunction<VV, EV, M> gather, SumFunction<VV, EV, M> sum,
+									ApplyFunction<K, VV, M> apply, DataSet<Edge<K, EV>> edges,
+									int maximumNumberOfIterations, int threshold) {
+
+		Preconditions.checkNotNull(gather);
+		Preconditions.checkNotNull(sum);
+		Preconditions.checkNotNull(apply);
+		Preconditions.checkNotNull(edges);
+		Preconditions.checkArgument(maximumNumberOfIterations > 0, "The maximum number of iterations must be at least one.");
+		Preconditions.checkNotNull(threshold);
+
+		this.gather = gather;
+		this.sum = sum;
+		this.apply = apply;
+		this.edgeDataSet = edges;
+		this.maximumNumberOfIterations = maximumNumberOfIterations;
+		this.threshold = threshold;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Custom Operator behavior
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Sets the input data set for this operator. In the case of this operator this input data set represents
+	 * the set of vertices with their initial state.
+	 *
+	 * @param dataSet The input data set, which in the case of this operator represents the set of
+	 *                vertices with their initial state.
+	 */
+	@Override
+	public void setInput(DataSet<Vertex<K, VV>> dataSet) {
+		this.vertexDataSet = dataSet;
+	}
+
+	/**
+	 * Computes the results of the gather-sum-apply iteration
+	 *
+	 * @return The resulting DataSet
+	 */
+	@Override
+	public DataSet<Vertex<K, VV>> createResult() {
+		if (vertexDataSet == null) {
+			throw new IllegalStateException("The input data set has not been set.");
+		}
+
+		// Prepare type information
+		TypeInformation<K> keyType = ((TupleTypeInfo<?>) vertexDataSet.getType()).getTypeAt(0);
+		TypeInformation<M> messageType = TypeExtractor.createTypeInfo(GatherFunction.class, gather.getClass(), 2, null, null);
+		TypeInformation<Tuple2<K, M>> innerType = new TupleTypeInfo<Tuple2<K, M>>(keyType, messageType);
+		TypeInformation<Vertex<K, VV>> outputType = vertexDataSet.getType();
+
+		// create a graph
+		Graph<K, VV, EV> graph =
+				Graph.fromDataSet(vertexDataSet, edgeDataSet, ExecutionEnvironment.getExecutionEnvironment());
+
+		// check whether the numVertices option is set and, if so, compute the total number of vertices
+		// and set it within the gather, sum and apply functions
+		if (this.configuration != null && this.configuration.isOptNumVertices()) {
+			try {
+				long numberOfVertices = graph.numberOfVertices();
+				gather.setNumberOfVertices(numberOfVertices);
+				sum.setNumberOfVertices(numberOfVertices);
+				apply.setNumberOfVertices(numberOfVertices);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+
+		// Prepare UDFs
+		GatherUdf<K, VV, EV, M> gatherUdf = new GatherUdf<K, VV, EV, M>(gather, innerType);
+		SumUdf<K, VV, EV, M> sumUdf = new SumUdf<K, VV, EV, M>(sum, innerType);
+		ApplyUdf<K, VV, EV, M> applyUdf = new ApplyUdf<K, VV, EV, M>(apply, outputType);
+
+		final int[] zeroKeyPos = new int[] {0};
+		final DeltaIteration<Vertex<K, VV>, Vertex<K, VV>> iteration =
+				vertexDataSet.iterateDelta(vertexDataSet, maximumNumberOfIterations, zeroKeyPos);
+
+		// set up the iteration operator
+		if (this.configuration != null) {
+
+			iteration.name(this.configuration.getName(
+					"Gather-sum-apply iteration (" + gather + " | " + sum + " | " + apply + ")"));
+			iteration.parallelism(this.configuration.getParallelism());
+			iteration.setSolutionSetUnManaged(this.configuration.isSolutionSetUnmanagedMemory());
+
+			// register all aggregators
+			for (Map.Entry<String, Aggregator<?>> entry : this.configuration.getAggregators().entrySet()) {
+				iteration.registerAggregator(entry.getKey(), entry.getValue());
+			}
+		}
+		else {
+			// no configuration provided; set default name
+			iteration.name("Gather-sum-apply iteration (" + gather + " | " + sum + " | " + apply + ")");
+		}
+
+		DataSet<Tuple2<K, Neighbor<VV, EV>>> neighbors = null;
+
+		if (this.configuration != null && this.configuration.isCustomPartition()) {
+
+			DataSet<Tuple2<K, Long>> verticesWithDegrees = graph.getDegrees();
+
+			DataSet<Edge<K, EV>> edgesWithHighDegreeTarget;
+			DataSet<Edge<K, EV>> edgesWithLowDegreeTarget;
+
+			try {
+				DataSet<Vertex<K, NullValue>> skewedVertices = determineSkewedVertices(threshold,
+						verticesWithDegrees);
+
+				DataSet<Vertex<K, NullValue>> unskewedVertices = determineUnskewedVertices(threshold,
+						verticesWithDegrees);
+
+				edgesWithHighDegreeTarget = edgeDataSet.join(skewedVertices).where(1).equalTo(0)
+						.with(new JoinFunction<Edge<K, EV>, Vertex<K, NullValue>, Edge<K, EV>>() {
+							@Override
+							public Edge<K, EV> join(Edge<K, EV> edge, Vertex<K, NullValue> vertex) throws Exception {
+								return edge;
+							}
+						});
+
+				edgesWithLowDegreeTarget = edgeDataSet.join(unskewedVertices).where(1).equalTo(0)
+						.with(new JoinFunction<Edge<K, EV>, Vertex<K, NullValue>, Edge<K, EV>>() {
+							@Override
+							public Edge<K, EV> join(Edge<K, EV> edge, Vertex<K, NullValue> vertex) throws Exception {
+								return edge;
+							}
+						});
+
+				// edges with high degree target will be partitioned on source
+				edgesWithHighDegreeTarget.sortPartition(0, Order.ASCENDING);
+
+				// edges with low degree target will be partitioned on target
+				edgesWithLowDegreeTarget.sortPartition(1, Order.ASCENDING);
+
+				DataSet<Tuple2<K, Neighbor<VV, EV>>> neighborsHigh = iteration
+						.getWorkset().join(edgesWithHighDegreeTarget, JoinOperatorBase.JoinHint.BROADCAST_HASH_FIRST)
+						.where(0).equalTo(0).with(new ProjectKeyWithNeighbor<K, VV, EV>());
+				DataSet<Tuple2<K, Neighbor<VV, EV>>> neighborsLow = iteration
+						.getWorkset().join(edgesWithLowDegreeTarget, JoinOperatorBase.JoinHint.BROADCAST_HASH_FIRST)
+						.where(0).equalTo(0).with(new ProjectKeyWithNeighbor<K, VV, EV>());
+
+				neighbors = neighborsHigh.union(neighborsLow);
+
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
+		} else {
+			// Prepare the neighbors
+		 	neighbors= iteration
+					.getWorkset().join(edgeDataSet)
+					.where(0).equalTo(0).with(new ProjectKeyWithNeighbor<K, VV, EV>());
+		}
+
+		// Gather, sum and apply
+		MapOperator<Tuple2<K, Neighbor<VV, EV>>, Tuple2<K, M>> gatherMapOperator = neighbors.map(gatherUdf);
+
+		// configure map gather function with name and broadcast variables
+		gatherMapOperator = gatherMapOperator.name("Gather");
+
+		if (this.configuration != null) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getGatherBcastVars()) {
+				gatherMapOperator = gatherMapOperator.withBroadcastSet(e.f1, e.f0);
+			}
+		}
+
+		DataSet<Tuple2<K, M>> gatheredSet = gatherMapOperator;
+
+		ReduceOperator<Tuple2<K, M>> sumReduceOperator = gatheredSet.groupBy(0).reduce(sumUdf);
+
+		// configure reduce sum function with name and broadcast variables
+		sumReduceOperator = sumReduceOperator.name("Sum");
+
+		if (this.configuration != null) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getSumBcastVars()) {
+				sumReduceOperator = sumReduceOperator.withBroadcastSet(e.f1, e.f0);
+			}
+		}
+
+		DataSet<Tuple2<K, M>> summedSet = sumReduceOperator;
+
+		JoinOperator<?, ?, Vertex<K, VV>> appliedSet = summedSet
+				.join(iteration.getSolutionSet())
+				.where(0)
+				.equalTo(0)
+				.with(applyUdf);
+
+		// configure join apply function with name and broadcast variables
+		appliedSet = appliedSet.name("Apply");
+
+		if (this.configuration != null) {
+			for (Tuple2<String, DataSet<?>> e : this.configuration.getApplyBcastVars()) {
+				appliedSet = appliedSet.withBroadcastSet(e.f1, e.f0);
+			}
+		}
+
+		// let the operator know that we preserve the key field
+		appliedSet.withForwardedFieldsFirst("0").withForwardedFieldsSecond("0");
+
+		return iteration.closeWith(appliedSet, appliedSet);
+	}
+
+	/**
+	 * Creates a new gather-sum-apply iteration operator for graphs
+	 *
+	 * @param edges The edge DataSet
+	 *
+	 * @param gather The gather function of the GSA iteration
+	 * @param sum The sum function of the GSA iteration
+	 * @param apply The apply function of the GSA iteration
+	 *
+	 * @param maximumNumberOfIterations The maximum number of iterations executed
+	 *
+	 * @param <K> The type of the vertex key in the graph
+	 * @param <VV> The type of the vertex value in the graph
+	 * @param <EV> The type of the edge value in the graph
+	 * @param <M> The intermediate type used by the gather, sum and apply functions
+	 *
+	 * @return An in stance of the gather-sum-apply graph computation operator.
+	 */
+	public static final <K, VV, EV, M> GatherSumApplyIteration<K, VV, EV, M>
+	withEdges(DataSet<Edge<K, EV>> edges, GatherFunction<VV, EV, M> gather,
+			  SumFunction<VV, EV, M> sum, ApplyFunction<K, VV, M> apply, int maximumNumberOfIterations) {
+
+		return new GatherSumApplyIteration<K, VV, EV, M>(gather, sum, apply, edges, maximumNumberOfIterations);
+	}
+
+	public static final <K, VV, EV, M> GatherSumApplyIteration<K, VV, EV, M>
+	withEdges(DataSet<Edge<K, EV>> edges, GatherFunction<VV, EV, M> gather,
+			  SumFunction<VV, EV, M> sum, ApplyFunction<K, VV, M> apply, int maximumNumberOfIterations,
+			  int threshold) {
+
+		return new GatherSumApplyIteration<K, VV, EV, M>(gather, sum, apply, edges, maximumNumberOfIterations, threshold);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Wrapping UDFs
+	// --------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("serial")
+	@FunctionAnnotation.ForwardedFields("f0")
+	private static final class GatherUdf<K, VV, EV, M> extends RichMapFunction<Tuple2<K, Neighbor<VV, EV>>,
+			Tuple2<K, M>> implements ResultTypeQueryable<Tuple2<K, M>> {
+
+		private final GatherFunction<VV, EV, M> gatherFunction;
+		private transient TypeInformation<Tuple2<K, M>> resultType;
+
+		private GatherUdf(GatherFunction<VV, EV, M> gatherFunction, TypeInformation<Tuple2<K, M>> resultType) {
+			this.gatherFunction = gatherFunction;
+			this.resultType = resultType;
+		}
+
+		@Override
+		public Tuple2<K, M> map(Tuple2<K, Neighbor<VV, EV>> neighborTuple) {
+			M result = this.gatherFunction.gather(neighborTuple.f1);
+			return new Tuple2<K, M>(neighborTuple.f0, result);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
+				this.gatherFunction.init(getIterationRuntimeContext());
+			}
+			this.gatherFunction.preSuperstep();
+		}
+
+		@Override
+		public void close() throws Exception {
+			this.gatherFunction.postSuperstep();
+		}
+
+		@Override
+		public TypeInformation<Tuple2<K, M>> getProducedType() {
+			return this.resultType;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class SumUdf<K, VV, EV, M> extends RichReduceFunction<Tuple2<K, M>>
+			implements ResultTypeQueryable<Tuple2<K, M>>{
+
+		private final SumFunction<VV, EV, M> sumFunction;
+		private transient TypeInformation<Tuple2<K, M>> resultType;
+
+		private SumUdf(SumFunction<VV, EV, M> sumFunction, TypeInformation<Tuple2<K, M>> resultType) {
+			this.sumFunction = sumFunction;
+			this.resultType = resultType;
+		}
+
+		@Override
+		public Tuple2<K, M> reduce(Tuple2<K, M> arg0, Tuple2<K, M> arg1) throws Exception {
+			K key = arg0.f0;
+			M result = this.sumFunction.sum(arg0.f1, arg1.f1);
+			return new Tuple2<K, M>(key, result);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
+				this.sumFunction.init(getIterationRuntimeContext());
+			}
+			this.sumFunction.preSuperstep();
+		}
+
+		@Override
+		public void close() throws Exception {
+			this.sumFunction.postSuperstep();
+		}
+
+		@Override
+		public TypeInformation<Tuple2<K, M>> getProducedType() {
+			return this.resultType;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static final class ApplyUdf<K, VV, EV, M> extends RichFlatJoinFunction<Tuple2<K, M>,
+			Vertex<K, VV>, Vertex<K, VV>> implements ResultTypeQueryable<Vertex<K, VV>> {
+
+		private final ApplyFunction<K, VV, M> applyFunction;
+		private transient TypeInformation<Vertex<K, VV>> resultType;
+
+		private ApplyUdf(ApplyFunction<K, VV, M> applyFunction, TypeInformation<Vertex<K, VV>> resultType) {
+			this.applyFunction = applyFunction;
+			this.resultType = resultType;
+		}
+
+		@Override
+		public void join(Tuple2<K, M> newValue, final Vertex<K, VV> currentValue, final Collector<Vertex<K, VV>> out) throws Exception {
+
+			this.applyFunction.setOutput(currentValue, out);
+			this.applyFunction.apply(newValue.f1, currentValue.getValue());
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			if (getIterationRuntimeContext().getSuperstepNumber() == 1) {
+				this.applyFunction.init(getIterationRuntimeContext());
+			}
+			this.applyFunction.preSuperstep();
+		}
+
+		@Override
+		public void close() throws Exception {
+			this.applyFunction.postSuperstep();
+		}
+
+		@Override
+		public TypeInformation<Vertex<K, VV>> getProducedType() {
+			return this.resultType;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	@FunctionAnnotation.ForwardedFieldsSecond("f1->f0")
+	private static final class ProjectKeyWithNeighbor<K, VV, EV> implements FlatJoinFunction<
+			Vertex<K, VV>, Edge<K, EV>, Tuple2<K, Neighbor<VV, EV>>> {
+
+		public void join(Vertex<K, VV> vertex, Edge<K, EV> edge, Collector<Tuple2<K, Neighbor<VV, EV>>> out) {
+			out.collect(new Tuple2<K, Neighbor<VV, EV>>(
+					edge.getTarget(), new Neighbor<VV, EV>(vertex.getValue(), edge.getValue())));
+		}
+	}
+
+	/**
+	 * Configures this gather-sum-apply iteration with the provided parameters.
+	 *
+	 * @param parameters the configuration parameters
+	 */
+	public void configure(GSAConfiguration parameters) {
+		this.configuration = parameters;
+	}
+
+	/**
+	 * @return the configuration parameters of this gather-sum-apply iteration
+	 */
+	public GSAConfiguration getIterationConfiguration() {
+		return this.configuration;
+	}
+
+	public static <K> DataSet<Vertex<K, NullValue>> determineUnskewedVertices(final double xMin,
+																		   DataSet<Tuple2<K, Long>> verticesWithDegrees) throws Exception {
+		return verticesWithDegrees
+				.flatMap(new FlatMapFunction<Tuple2<K, Long>, Vertex<K, NullValue>>() {
+
+					@Override
+					public void flatMap(Tuple2<K, Long> vertexIdDegree,
+										Collector<Vertex<K, NullValue>> collector) throws Exception {
+						if(vertexIdDegree.f1 <= xMin) {
+							collector.collect(new Vertex<K, NullValue>(vertexIdDegree.f0, NullValue.getInstance()));
+						}
+					}
+				});
+	}
+
+	public static <K> DataSet<Vertex<K, NullValue>> determineSkewedVertices(final double xMin,
+																			DataSet<Tuple2<K, Long>> verticesWithDegrees) throws Exception {
+		return verticesWithDegrees
+				.flatMap(new FlatMapFunction<Tuple2<K, Long>, Vertex<K, NullValue>>() {
+
+					@Override
+					public void flatMap(Tuple2<K, Long> vertexIdDegree,
+										Collector<Vertex<K, NullValue>> collector) throws Exception {
+						if(vertexIdDegree.f1 > xMin) {
+							collector.collect(new Vertex<K, NullValue>(vertexIdDegree.f0, NullValue.getInstance()));
+						}
+					}
+				});
+	}
+}
+

--- a/src/main/java/partitioning/gsa/Neighbor.java
+++ b/src/main/java/partitioning/gsa/Neighbor.java
@@ -1,0 +1,27 @@
+package partitioning.gsa;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+/**
+ * This class represents a <sourceVertex, edge> pair
+ * This is a wrapper around Tuple2<VV, EV> for convenience in the GatherFunction
+ * @param <VV> the vertex value type
+ * @param <EV> the edge value type
+ */
+@SuppressWarnings("serial")
+public class Neighbor<VV, EV> extends Tuple2<VV, EV> {
+
+	public Neighbor() {}
+
+	public Neighbor(VV neighborValue, EV edgeValue) {
+		super(neighborValue, edgeValue);
+	}
+
+	public VV getNeighborValue() {
+		return this.f0;
+	}
+
+	public EV getEdgeValue() {
+		return this.f1;
+	}
+}

--- a/src/main/java/partitioning/gsa/SumFunction.java
+++ b/src/main/java/partitioning/gsa/SumFunction.java
@@ -1,0 +1,101 @@
+package partitioning.gsa;
+
+import org.apache.flink.api.common.aggregators.Aggregator;
+import org.apache.flink.api.common.functions.IterationRuntimeContext;
+import org.apache.flink.types.Value;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+@SuppressWarnings("serial")
+public abstract class SumFunction<VV, EV, M> implements Serializable {
+
+	// --------------------------------------------------------------------------------------------
+	//  Attribute that allows access to the total number of vertices inside an iteration.
+	// --------------------------------------------------------------------------------------------
+
+	private long numberOfVertices = -1L;
+
+	/**
+	 * Retrieves the number of vertices in the graph.
+	 * @return the number of vertices if the {@link IterationConfigurationion#setOptNumVertices(boolean)}
+	 * option has been set; -1 otherwise.
+	 */
+	public long getNumberOfVertices() {
+		return numberOfVertices;
+	}
+
+	void setNumberOfVertices(long numberOfVertices) {
+		this.numberOfVertices = numberOfVertices;
+	}
+
+	//---------------------------------------------------------------------------------------------
+
+	public abstract M sum(M arg0, M arg1);
+
+	/**
+	 * This method is executed once per superstep before the vertex update function is invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the pre-superstep phase cause the superstep to fail.
+	 */
+	public void preSuperstep() {}
+
+	/**
+	 * This method is executed once per superstep after the vertex update function has been invoked for each vertex.
+	 *
+	 * @throws Exception Exceptions in the post-superstep phase cause the superstep to fail.
+	 */
+	public void postSuperstep() {}
+
+	/**
+	 * Gets the number of the superstep, starting at <tt>1</tt>.
+	 *
+	 * @return The number of the current superstep.
+	 */
+	public int getSuperstepNumber() {
+		return this.runtimeContext.getSuperstepNumber();
+	}
+
+	/**
+	 * Gets the iteration aggregator registered under the given name. The iteration aggregator combines
+	 * all aggregates globally once per superstep and makes them available in the next superstep.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregator registered under this name, or null, if no aggregator was registered.
+	 */
+	public <T extends Aggregator<?>> T getIterationAggregator(String name) {
+		return this.runtimeContext.<T>getIterationAggregator(name);
+	}
+
+	/**
+	 * Get the aggregated value that an aggregator computed in the previous iteration.
+	 *
+	 * @param name The name of the aggregator.
+	 * @return The aggregated value of the previous iteration.
+	 */
+	public <T extends Value> T getPreviousIterationAggregate(String name) {
+		return this.runtimeContext.<T>getPreviousIterationAggregate(name);
+	}
+
+	/**
+	 * Gets the broadcast data set registered under the given name. Broadcast data sets
+	 * are available on all parallel instances of a function.
+	 *
+	 * @param name The name under which the broadcast set is registered.
+	 * @return The broadcast data set.
+	 */
+	public <T> Collection<T> getBroadcastSet(String name) {
+		return this.runtimeContext.<T>getBroadcastVariable(name);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Internal methods
+	// --------------------------------------------------------------------------------------------
+
+	private IterationRuntimeContext runtimeContext;
+
+	public void init(IterationRuntimeContext iterationRuntimeContext) {
+		this.runtimeContext = iterationRuntimeContext;
+	}
+}
+


### PR DESCRIPTION
This adds a partitioning section to the src folder of the thesis containing:
- a SourcePartition class; for partitioning high degree nodes
- a TargetPartition class; for partitioning the low degree nodes
- two examples used to test the hybrid-cut approach (see image
  ![hybrid-cut](https://cloud.githubusercontent.com/assets/2550549/9036868/f0681978-39e5-11e5-8665-05034ba13658.png)
  ): in ExamplePartitioning, high-degree vertices are partitioned by hashing the source, whereas low degree vertices are partitioned by hashing the target; in MirroredExample, the same operations are performed, this time, using Flink's default partitioner. 

The results depend, as usual, on the graph's skew:

```
             FRIENDSTER (-p60)
```

Mirror:
Task Manager has been released exception

PartExample:
time started: 08/03/2015 12:10:43
time ended: 08/03/2015 12:16:56

```
    ORKUT (-p60)
```

Mirror:
time started: 08/03/2015 13:11:39 
time ended: 08/03/2015 13:12:18
39s

PartExample:
time started: 08/03/2015 13:12:22  
time ended: 08/03/2015 13:12:44
22s

```
    TWITTER (-p60)
```

Mirror:
time started: 08/03/2015 13:24:50 
time ended: 08/03/2015 13:28:59
4min 9s 

PartExample:
time started: 08/03/2015 13:29:04
time ended: 08/03/2015 13:35:58
6min 54s

Next step is to try something similar on Jaccard and then on Connected Componets, to see what  happens for more complex operations. 
